### PR TITLE
Relax eslint rules and fix errors

### DIFF
--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -12,6 +12,8 @@
   ],
   "rules": {
     "@typescript-eslint/ban-ts-comment": "warn",
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-explicit-any": "off",
     "comma-dangle": "off",
     "multiline-ternary": "off",
     "no-use-before-define": "off",
@@ -19,6 +21,7 @@
     "react/prop-types": "off",
     "react/no-unescaped-entities": "off",
     "react/display-name": "off",
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "react/jsx-no-target-blank": "off"
   }
 }

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -3,6 +3,9 @@
     "browser": true,
     "es2021": true
   },
+  "settings": {
+    "react": { "version": "detect" }
+  },
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "extends": [

--- a/server/package.json
+++ b/server/package.json
@@ -2,7 +2,8 @@
   "name": "coflux",
   "private": true,
   "scripts": {
-    "build": "node ./esbuild.js"
+    "build": "node ./esbuild.js",
+    "lint": "eslint ./src"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.688.0",

--- a/server/src/components/NewProjectDialog.tsx
+++ b/server/src/components/NewProjectDialog.tsx
@@ -18,9 +18,7 @@ function translateProjectNameError(error: string | undefined) {
   }
 }
 
-type Props = {};
-
-export default function NewProjectDialog({}: Props) {
+export default function NewProjectDialog() {
   const [projectName, setProjectName] = useState("My Project");
   const [errors, setErrors] = useState<Record<string, string>>();
   const [creating, setCreating] = useState(false);

--- a/server/src/utils.ts
+++ b/server/src/utils.ts
@@ -18,7 +18,7 @@ export function choose(values: string[]): string {
 }
 
 export function humanSize(size: number) {
-  var i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+  const i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
   return [
     Number((size / Math.pow(1024, i)).toFixed(2)),
     ["bytes", "kB", "MB", "GB", "TB"][i],


### PR DESCRIPTION
I've relaxed the existing eslint rules:
- `"@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]` means that unused arguments prefixed with `_` won't be flagged
- `"@typescript-eslint/no-explicit-any": "off"` will stop eslint from complaining about the use of the `any` type
- `"react/jsx-no-target-blank": "off"` will stop eslint from complaining about the security issues caused by using `target="_blank"` without `rel="noopener"` in older browsers 

I've also added a `lint` script to npm to run eslint.

Once the remaining error and 22 warnings emitted by eslint are fixed, we'll be able to run `npm run lint` as part of CI.