### PR TITLE
Rename 'env' command group

### DIFF
--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -313,14 +313,14 @@ def configure(
 
 
 @cli.group()
-def workspace():
+def workspaces():
     """
     Manage workspaces.
     """
     pass
 
 
-@workspace.command("create")
+@workspaces.command("create")
 @click.option(
     "-p",
     "--project",
@@ -344,7 +344,7 @@ def workspace():
     help="The base workspace to inherit from",
 )
 @click.argument("name")
-def workspace_create(
+def workspaces_create(
     project: str,
     host: str,
     base: str | None,
@@ -377,7 +377,7 @@ def workspace_create(
     click.secho(f"Created workspace '{name}'.", fg="green")
 
 
-@workspace.command("update")
+@workspaces.command("update")
 @click.option(
     "-p",
     "--project",
@@ -418,7 +418,7 @@ def workspace_create(
     is_flag=True,
     help="Unset the base workspace",
 )
-def workspace_update(
+def workspaces_update(
     project: str,
     workspace: str,
     host: str,
@@ -461,7 +461,7 @@ def workspace_update(
     click.secho(f"Updated workspace '{name or workspace}'.", fg="green")
 
 
-@workspace.command("archive")
+@workspaces.command("archive")
 @click.option(
     "-p",
     "--project",
@@ -489,7 +489,7 @@ def workspace_update(
     show_default=True,
     required=True,
 )
-def workspace_archive(
+def workspaces_archive(
     project: str,
     workspace: str,
     host: str,
@@ -517,13 +517,13 @@ def workspace_archive(
     click.secho(f"Archived workspace '{workspace}'.", fg="green")
 
 @cli.group()
-def pool():
+def pools():
     """
     Manage pools.
     """
     pass
 
-@pool.command("update")
+@pools.command("update")
 @click.option(
     "-p",
     "--project",
@@ -574,7 +574,7 @@ def pool():
     help="The Docker image. Only valid for --launcher=docker.",
 )
 @click.argument("name")
-def pool_update(
+def pools_update(
     project: str,
     workspace: str,
     host: str,
@@ -609,7 +609,7 @@ def pool_update(
     )
 
 
-@pool.command("delete")
+@pools.command("delete")
 @click.option(
     "-p",
     "--project",
@@ -638,7 +638,7 @@ def pool_update(
     required=True,
 )
 @click.argument("name")
-def pool_delete(
+def pools_delete(
     project: str,
     workspace: str,
     host: str,

--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -517,13 +517,13 @@ def workspace_archive(
     click.secho(f"Archived workspace '{workspace}'.", fg="green")
 
 @cli.group()
-def pools():
+def pool():
     """
     Manage pools.
     """
     pass
 
-@pools.command("update")
+@pool.command("update")
 @click.option(
     "-p",
     "--project",
@@ -574,7 +574,7 @@ def pools():
     help="The Docker image. Only valid for --launcher=docker.",
 )
 @click.argument("name")
-def pools_update(
+def pool_update(
     project: str,
     workspace: str,
     host: str,
@@ -609,7 +609,7 @@ def pools_update(
     )
 
 
-@pools.command("delete")
+@pool.command("delete")
 @click.option(
     "-p",
     "--project",
@@ -638,7 +638,7 @@ def pools_update(
     required=True,
 )
 @click.argument("name")
-def pools_delete(
+def pool_delete(
     project: str,
     workspace: str,
     host: str,

--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -313,14 +313,14 @@ def configure(
 
 
 @cli.group()
-def env():
+def workspace():
     """
     Manage workspaces.
     """
     pass
 
 
-@env.command("create")
+@workspace.command("create")
 @click.option(
     "-p",
     "--project",
@@ -344,7 +344,7 @@ def env():
     help="The base workspace to inherit from",
 )
 @click.argument("name")
-def env_create(
+def workspace_create(
     project: str,
     host: str,
     base: str | None,
@@ -377,7 +377,7 @@ def env_create(
     click.secho(f"Created workspace '{name}'.", fg="green")
 
 
-@env.command("update")
+@workspace.command("update")
 @click.option(
     "-p",
     "--project",
@@ -418,7 +418,7 @@ def env_create(
     is_flag=True,
     help="Unset the base workspace",
 )
-def env_update(
+def workspace_update(
     project: str,
     workspace: str,
     host: str,
@@ -461,7 +461,7 @@ def env_update(
     click.secho(f"Updated workspace '{name or workspace}'.", fg="green")
 
 
-@env.command("archive")
+@workspace.command("archive")
 @click.option(
     "-p",
     "--project",
@@ -489,7 +489,7 @@ def env_update(
     show_default=True,
     required=True,
 )
-def env_archive(
+def workspace_archive(
     project: str,
     workspace: str,
     host: str,


### PR DESCRIPTION
This renames the 'env' CLI command group to 'workspaces', which was missed out from #71.