### PR TITLE
Add support for groups

### DIFF
--- a/clients/python/coflux/__init__.py
+++ b/clients/python/coflux/__init__.py
@@ -1,5 +1,6 @@
 from .decorators import workflow, task, stub, sensor
 from .context import (
+    group,
     checkpoint,
     suspense,
     suspend,
@@ -17,6 +18,7 @@ __all__ = [
     "task",
     "stub",
     "sensor",
+    "group",
     "checkpoint",
     "suspense",
     "suspend",

--- a/clients/python/coflux/context.py
+++ b/clients/python/coflux/context.py
@@ -47,6 +47,10 @@ def submit(
     )
 
 
+def group(name: str | None = None):
+    return _get_channel().group(name)
+
+
 def suspense(timeout: float | None):
     return _get_channel().suspense(timeout)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,7 @@
         "@tabler/icons-react": "^3.17.0",
         "@topical/react": "^0.3.1",
         "classnames": "^2.5.1",
-        "elkjs": "^0.9.3",
+        "elkjs": "^0.10.0",
         "lodash": "^4.17.21",
         "luxon": "^3.5.0",
         "micromark": "^4.0.1",
@@ -3533,9 +3533,10 @@
       "dev": true
     },
     "node_modules/elkjs": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
-      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.10.0.tgz",
+      "integrity": "sha512-v/3r+3Bl2NMrWmVoRTMBtHtWvRISTix/s9EfnsfEWApNrsmNjqgqJOispCGg46BPwIFdkag3N/HYSxJczvCm6w==",
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -10097,9 +10098,9 @@
       "dev": true
     },
     "elkjs": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
-      "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ=="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.10.0.tgz",
+      "integrity": "sha512-v/3r+3Bl2NMrWmVoRTMBtHtWvRISTix/s9EfnsfEWApNrsmNjqgqJOispCGg46BPwIFdkag3N/HYSxJczvCm6w=="
     },
     "emoji-regex": {
       "version": "9.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "@tabler/icons-react": "^3.17.0",
     "@topical/react": "^0.3.1",
     "classnames": "^2.5.1",
-    "elkjs": "^0.9.3",
+    "elkjs": "^0.10.0",
     "lodash": "^4.17.21",
     "luxon": "^3.5.0",
     "micromark": "^4.0.1",

--- a/frontend/src/components/AddWorkspaceDialog.tsx
+++ b/frontend/src/components/AddWorkspaceDialog.tsx
@@ -76,8 +76,9 @@ export default function AddWorkspaceDialog({
     <Dialog
       title="Add workspace"
       open={open}
+      size="md"
+      className="p-6"
       onClose={onClose}
-      className="p-6 max-w-lg"
     >
       {errors && (
         <Alert variant="warning">

--- a/frontend/src/components/AssetLink.tsx
+++ b/frontend/src/components/AssetLink.tsx
@@ -67,8 +67,8 @@ function PreviewDialog({
 }: FilePreviewProps) {
   if (showPreview(type)) {
     return (
-      <Dialog open={open} className="max-w-[80vw] h-[80vh]" onClose={onClose}>
-        <div className="h-full rounded-lg overflow-hidden flex flex-col min-w-2xl">
+      <Dialog open={open} size="xl" onClose={onClose}>
+        <div className="h-[80vh] rounded-lg overflow-hidden flex flex-col min-w-2xl">
           <iframe
             src={assetUrl(projectId, assetId, path)}
             sandbox="allow-downloads allow-forms allow-modals allow-scripts"
@@ -79,7 +79,7 @@ function PreviewDialog({
     );
   } else {
     return (
-      <Dialog open={open} className="p-6 max-w-sm" onClose={onClose}>
+      <Dialog open={open} size="sm" className="p-6" onClose={onClose}>
         <div className="flex justify-center">
           <a
             href={assetUrl(projectId, assetId, path)}
@@ -236,7 +236,8 @@ function DirectoryBrowser({
             </span>
           </div>
         }
-        className={"p-6 max-w-lg"}
+        size="sm"
+        className="p-6"
         onClose={onClose}
       >
         <div className="flex flex-col">

--- a/frontend/src/components/ExecutionStatus.tsx
+++ b/frontend/src/components/ExecutionStatus.tsx
@@ -1,0 +1,34 @@
+import Badge from "./Badge";
+import * as models from "../models";
+
+export type Props = {
+  execution: models.Execution;
+  step: models.Step;
+};
+
+export default function ExecutionStatus({ execution, step }: Props) {
+  return execution.result?.type == "cached" ? (
+    <Badge intent="none" label="Cached" />
+  ) : execution.result?.type == "spawned" ? (
+    <Badge intent="none" label="Spawned" />
+  ) : execution.result?.type == "deferred" ? (
+    <Badge intent="none" label="Deferred" />
+  ) : execution.result?.type == "value" ? (
+    <Badge intent="success" label="Completed" />
+  ) : execution.result?.type == "error" ? (
+    <Badge intent="danger" label="Failed" />
+  ) : execution.result?.type == "abandoned" ? (
+    <Badge intent="warning" label="Abandoned" />
+  ) : execution.result?.type == "suspended" ? (
+    <Badge intent="none" label="Suspended" />
+  ) : execution.result?.type == "cancelled" ? (
+    <Badge
+      intent="warning"
+      label={step.type == "sensor" ? "Stoppped" : "Cancelled"}
+    />
+  ) : !execution.assignedAt ? (
+    <Badge intent="info" label="Assigning" />
+  ) : !execution.result ? (
+    <Badge intent="info" label="Running" />
+  ) : null;
+}

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -1,0 +1,128 @@
+import Dialog from "./common/Dialog";
+import * as models from "../models";
+import StepLink from "./StepLink";
+import classNames from "classnames";
+import ExecutionStatus from "./ExecutionStatus";
+import { useCallback } from "react";
+import { max, omit } from "lodash";
+import { buildUrl } from "../utils";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import Value from "./Value";
+
+function findGroup(run: models.Run, identifier: string) {
+  const parts = identifier.split("-");
+  if (parts.length != 3) {
+    return undefined;
+  }
+  const stepId = parts[0];
+  const attempt = parseInt(parts[1], 10);
+  const groupId = parseInt(parts[2], 10);
+  const execution = run.steps[stepId]?.executions[attempt];
+  if (!execution || !(groupId in execution.groups)) {
+    return undefined;
+  }
+  const name = execution.groups[groupId];
+  const steps = execution.children
+    .filter((c) => c.groupId == groupId)
+    .map((c) => c.stepId)
+    .reduce<Record<string, number>>(
+      (acc, sId) => ({
+        ...acc,
+        [sId]: max(
+          Object.keys(run.steps[sId].executions).map((a) => parseInt(a, 10)),
+        )!,
+      }),
+      {},
+    );
+  return { name, steps };
+}
+
+type Props = {
+  runId: string;
+  run: models.Run;
+  identifier: string | null;
+  projectId: string;
+};
+
+export default function GroupDialog({
+  runId,
+  run,
+  identifier,
+  projectId,
+}: Props) {
+  const [searchParams] = useSearchParams();
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const group = identifier && findGroup(run, identifier);
+  const handleDialogClose = useCallback(() => {
+    navigate(
+      buildUrl(pathname, omit(Object.fromEntries(searchParams), "group")),
+    );
+  }, [searchParams, pathname, navigate]);
+  return (
+    <Dialog
+      open={!!identifier}
+      title={group ? group.name || <em>Unnamed group</em> : undefined}
+      onClose={handleDialogClose}
+      size="md"
+      className="p-6"
+    >
+      {group ? (
+        <ul className="flex flex-col overflow-auto divide-y">
+          {Object.entries(group.steps).map(([stepId, attempt]) => {
+            const step = run.steps[stepId];
+            const execution = step.executions[attempt];
+            return (
+              <li key={stepId} className="py-1">
+                <StepLink
+                  runId={runId}
+                  stepId={stepId}
+                  attempt={attempt}
+                  className={classNames(
+                    "p-1 cursor-pointer rounded flex flex-col data-[active]:bg-slate-100 hover:bg-slate-50",
+                  )}
+                  activeClassName="bg-slate-100"
+                >
+                  <div className="flex items-center gap-1">
+                    <div className="flex-1 flex items-baseline flex-wrap gap-1 leading-tight">
+                      <div className="flex items-baseline gap-1">
+                        <span className="text-slate-400 text-sm">
+                          {step.module}
+                        </span>
+                        <span className="text-slate-400">/</span>
+                      </div>
+                      <span className="flex items-baseline gap-1">
+                        <h2 className="font-mono">{step.target}</h2>
+                      </span>
+                    </div>
+                    <div className="flex gap-1 items-center">
+                      #{attempt}
+                      <ExecutionStatus execution={execution} step={step} />
+                    </div>
+                  </div>
+                  <div>
+                    {step.arguments.length > 0 && (
+                      <ol className="list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
+                        {step.arguments.map((argument, index) => (
+                          <li key={index}>
+                            <Value
+                              value={argument}
+                              projectId={projectId}
+                              className="align-middle"
+                            />
+                          </li>
+                        ))}
+                      </ol>
+                    )}
+                  </div>
+                </StepLink>
+              </li>
+            );
+          })}
+        </ul>
+      ) : identifier ? (
+        <p>Unrecognised group</p>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/frontend/src/components/NewProjectDialog.tsx
+++ b/frontend/src/components/NewProjectDialog.tsx
@@ -54,7 +54,8 @@ export default function NewProjectDialog() {
     <Dialog
       title="New project"
       open={true}
-      className="p-6 max-w-lg"
+      size="sm"
+      className="p-6"
       onClose={handleClose}
     >
       {errors && (

--- a/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/frontend/src/components/ProjectSettingsDialog.tsx
@@ -435,7 +435,7 @@ export default function SettingsDialog({ projectId, open, onClose }: Props) {
       title={<div className="px-4 pt-4">Project settings</div>}
       open={open}
       onClose={onClose}
-      className="max-w-2xl"
+      size="lg"
     >
       <form onSubmit={handleSubmit}>
         <Tabs>

--- a/frontend/src/components/RunDialog.tsx
+++ b/frontend/src/components/RunDialog.tsx
@@ -112,7 +112,7 @@ export default function RunDialog({
           />
         </div>
       }
-      className="max-w-2xl"
+      size="lg"
       open={open}
       onClose={onClose}
     >

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -445,7 +445,11 @@ export default function RunGraph({
   useEffect(() => {
     buildGraph(run, runId, activeStepId, activeAttempt)
       .then(setGraph)
-      .catch(() => setGraph(undefined)); // TODO: handle error
+      .catch((e) => {
+        setGraph(undefined);
+        // TODO: handle error
+        console.error(e);
+      });
   }, [run, runId, activeStepId, activeAttempt]);
   const graphWidth = graph?.width || 0;
   const graphHeight = graph?.height || 0;

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -519,6 +519,26 @@ function calculateMargins(
   return [marginX, marginY];
 }
 
+function useGraph(
+  run: models.Run,
+  runId: string,
+  activeStepId: string | undefined,
+  activeAttempt: number | undefined,
+) {
+  const [graph, setGraph] = useState<Graph>();
+  useEffect(() => {
+    buildGraph(run, runId, activeStepId, activeAttempt)
+      .then(setGraph)
+      .catch((e) => {
+        setGraph(undefined);
+        // TODO: handle error
+        console.error(e);
+      });
+  }, [run, runId, activeStepId, activeAttempt]);
+  // return graph?.runId == runId ? graph : undefined;
+  return graph;
+}
+
 type Props = {
   projectId: string;
   runId: string;
@@ -545,16 +565,7 @@ export default function RunGraph({
   const [dragging, setDragging] = useState<[number, number]>();
   const [zoomOverride, setZoomOverride] = useState<number>();
   const { isHovered } = useHoverContext();
-  const [graph, setGraph] = useState<Graph>();
-  useEffect(() => {
-    buildGraph(run, runId, activeStepId, activeAttempt)
-      .then(setGraph)
-      .catch((e) => {
-        setGraph(undefined);
-        // TODO: handle error
-        console.error(e);
-      });
-  }, [run, runId, activeStepId, activeAttempt]);
+  const graph = useGraph(run, runId, activeStepId, activeAttempt);
   const graphWidth = graph?.width || 0;
   const graphHeight = graph?.height || 0;
   const [marginX, marginY] = calculateMargins(

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -385,11 +385,15 @@ function GroupHeader({ group, runId, run }: GroupHeaderProps) {
   const counts = countBy(executions, getExecutionStatus);
   return (
     <div className="flex items-center gap-2">
-      <div
-        className="text-slate-600 text-sm overflow-hidden whitespace-nowrap text-ellipsis flex-1 pointer-events-auto"
-        title={`Group: ${group.name}`}
-      >
-        {group.name}
+      <div className="flex min-w-0 overflow-hidden mr-auto">
+        {group.name ? (
+          <span
+            className="bg-white block text-slate-600 text-sm overflow-hidden whitespace-nowrap text-ellipsis pointer-events-auto px-1 rounded"
+            title={`Group: ${group.name}`}
+          >
+            {group.name}
+          </span>
+        ) : null}
       </div>
       <div className="flex gap-1 bg-white rounded-md p-0.5 pointer-events-auto">
         {(
@@ -425,7 +429,7 @@ function GroupHeader({ group, runId, run }: GroupHeaderProps) {
         <MenuItems
           transition
           className="p-1 overflow-auto bg-white shadow-xl rounded-md origin-top transition duration-200 ease-out data-[closed]:scale-95 data-[closed]:opacity-0"
-          anchor={{ to: "top start", gap: 2, padding: 20 }}
+          anchor={{ to: "top end", gap: 2, padding: 20 }}
         >
           {Object.entries(group.steps).map(([stepId, attempt]) => (
             <MenuItem key={stepId}>

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import classNames from "classnames";
 import {
-  IconArrowUpRight,
+  IconArrowUpLeft,
   IconBolt,
   IconClock,
   IconArrowDownRight,
@@ -364,7 +364,7 @@ function ChildNode({ child }: ChildNodeProps) {
       className="flex-1 w-full h-full flex items-center px-2 py-1 border border-slate-300 rounded-full bg-white ring-offset-2"
       hoveredClassName="ring ring-slate-400"
     >
-      <IconArrowUpRight size={20} className="text-slate-400" />
+      <IconArrowUpLeft size={20} className="text-slate-400" />
       <span className="text-slate-500 font-bold flex-1 text-end">
         {child.runId}
       </span>

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -473,13 +473,7 @@ type EdgePathProps = {
 function EdgePath({ edge, offset, highlight }: EdgePathProps) {
   return (
     <path
-      className={
-        highlight
-          ? "stroke-slate-400"
-          : edge.type == "transitive"
-            ? "stroke-slate-100"
-            : "stroke-slate-200"
-      }
+      className={highlight ? "stroke-slate-400" : "stroke-slate-200"}
       fill="none"
       strokeWidth={
         edge.type == "asset"

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -385,10 +385,13 @@ function GroupHeader({ group, runId, run }: GroupHeaderProps) {
   const counts = countBy(executions, getExecutionStatus);
   return (
     <div className="flex items-center gap-2">
-      <div className="text-slate-600 text-sm overflow-hidden whitespace-nowrap text-ellipsis flex-1">
+      <div
+        className="text-slate-600 text-sm overflow-hidden whitespace-nowrap text-ellipsis flex-1 pointer-events-auto"
+        title={`Group: ${group.name}`}
+      >
         {group.name}
       </div>
-      <div className="flex gap-1 bg-white rounded-md p-0.5">
+      <div className="flex gap-1 bg-white rounded-md p-0.5 pointer-events-auto">
         {(
           [
             "running",
@@ -415,7 +418,7 @@ function GroupHeader({ group, runId, run }: GroupHeaderProps) {
         )}
       </div>
       <Menu>
-        <MenuButton className="flex items-center gap-1 p-1 pl-2 text-left text-slate-600 text-xs rounded-md border border-slate-300 bg-white shadow-sm hover:bg-slate-100 whitespace-nowrap">
+        <MenuButton className="flex items-center gap-1 p-1 pl-2 text-left text-slate-600 text-xs rounded-md border border-slate-300 bg-white shadow-sm hover:bg-slate-100 whitespace-nowrap pointer-events-auto">
           {group.activeStepId}
           <IconChevronDown size={16} className="opacity-50" />
         </MenuButton>
@@ -691,7 +694,7 @@ export default function RunGraph({
             Object.entries(graph.groups).map(([id, group]) => (
               <div
                 key={id}
-                className="absolute flex flex-col px-4"
+                className="absolute flex flex-col px-3 pointer-events-none"
                 style={{
                   left: group.x + marginX,
                   top: group.y + marginY,

--- a/frontend/src/components/StepDetail.tsx
+++ b/frontend/src/components/StepDetail.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import classNames from "classnames";
-import { minBy, sortBy } from "lodash";
+import { groupBy, minBy, sortBy } from "lodash";
 import { DateTime, Duration } from "luxon";
 import {
   Menu,
@@ -835,23 +835,38 @@ function RelationsSection({
         <h3 className="uppercase text-sm font-bold text-slate-400">Children</h3>
         {execution.children.length ? (
           <ul>
-            {execution.children.map((child) => {
-              const step = run.steps[child.stepId];
-              return (
-                <li key={`${child.stepId}/${child.attempt}`}>
-                  <StepLink
-                    runId={runId}
-                    stepId={child.stepId}
-                    attempt={child.attempt}
-                    className="rounded text-sm ring-offset-1 px-1"
-                    hoveredClassName="ring-2 ring-slate-300"
-                  >
-                    <span className="font-mono">{step.target}</span>{" "}
-                    <span className="text-slate-500">({step.module})</span>
-                  </StepLink>
+            {Object.entries(groupBy(execution.children, "groupId")).map(
+              ([groupId, children]) => (
+                <li key={groupId}>
+                  {groupId != "null" && (
+                    <h4 className="text-slate-600 mt-2">
+                      {execution.groups[groupId]}
+                    </h4>
+                  )}
+                  <ul>
+                    {children.map((child) => {
+                      const step = run.steps[child.stepId];
+                      return (
+                        <li key={`${child.stepId}/${child.attempt}`}>
+                          <StepLink
+                            runId={runId}
+                            stepId={child.stepId}
+                            attempt={child.attempt}
+                            className="rounded text-sm ring-offset-1 px-1"
+                            hoveredClassName="ring-2 ring-slate-300"
+                          >
+                            <span className="font-mono">{step.target}</span>{" "}
+                            <span className="text-slate-500">
+                              ({step.module})
+                            </span>
+                          </StepLink>
+                        </li>
+                      );
+                    })}
+                  </ul>
                 </li>
-              );
-            })}
+              ),
+            )}
           </ul>
         ) : (
           <p className="italic">None</p>

--- a/frontend/src/components/StepDetail.tsx
+++ b/frontend/src/components/StepDetail.tsx
@@ -6,7 +6,7 @@ import {
   useState,
 } from "react";
 import classNames from "classnames";
-import { groupBy, minBy, sortBy } from "lodash";
+import { isNil, minBy, sortBy } from "lodash";
 import { DateTime, Duration } from "luxon";
 import {
   Menu,
@@ -18,7 +18,12 @@ import {
   PopoverButton,
   PopoverPanel,
 } from "@headlessui/react";
-import { Link, useLocation, useNavigate } from "react-router-dom";
+import {
+  Link,
+  useLocation,
+  useNavigate,
+  useSearchParams,
+} from "react-router-dom";
 import {
   IconChevronDown,
   IconChevronLeft,
@@ -46,6 +51,7 @@ import Tabs, { Tab } from "./common/Tabs";
 import Select from "./common/Select";
 import Value from "./Value";
 import TagSet from "./TagSet";
+import ExecutionStatus from "./ExecutionStatus";
 
 function getRunWorkspaceId(run: models.Run) {
   const initialStepId = minBy(
@@ -53,38 +59,6 @@ function getRunWorkspaceId(run: models.Run) {
     (stepId) => run.steps[stepId].createdAt,
   )!;
   return run.steps[initialStepId].executions[1].workspaceId;
-}
-
-type ExecutionStatusProps = {
-  execution: models.Execution;
-  step: models.Step;
-};
-
-function ExecutionStatus({ execution, step }: ExecutionStatusProps) {
-  return execution.result?.type == "cached" ? (
-    <Badge intent="none" label="Cached" />
-  ) : execution.result?.type == "spawned" ? (
-    <Badge intent="none" label="Spawned" />
-  ) : execution.result?.type == "deferred" ? (
-    <Badge intent="none" label="Deferred" />
-  ) : execution.result?.type == "value" ? (
-    <Badge intent="success" label="Completed" />
-  ) : execution.result?.type == "error" ? (
-    <Badge intent="danger" label="Failed" />
-  ) : execution.result?.type == "abandoned" ? (
-    <Badge intent="warning" label="Abandoned" />
-  ) : execution.result?.type == "suspended" ? (
-    <Badge intent="none" label="Suspended" />
-  ) : execution.result?.type == "cancelled" ? (
-    <Badge
-      intent="warning"
-      label={step.type == "sensor" ? "Stoppped" : "Cancelled"}
-    />
-  ) : !execution.assignedAt ? (
-    <Badge intent="info" label="Assigning" />
-  ) : !execution.result ? (
-    <Badge intent="info" label="Running" />
-  ) : null;
 }
 
 function getNextPrevious(
@@ -564,7 +538,7 @@ function ArgumentsSection({ arguments_, projectId }: ArgumentsSectionProps) {
     <div>
       <h3 className="uppercase text-sm font-bold text-slate-400">Arguments</h3>
       {arguments_.length > 0 ? (
-        <ol className="list-decimal list-inside ml-1 marker:text-slate-400 marker:text-xs space-y-1 mt-1">
+        <ol className="list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1 mt-1">
           {arguments_.map((argument, index) => (
             <li key={index}>
               <Value
@@ -733,7 +707,7 @@ function DependenciesSection({ execution }: DependenciesSectionProps) {
         Dependencies
       </h3>
       {Object.keys(execution.dependencies).length > 0 ? (
-        <ul>
+        <ul className="flex flex-col gap-1 mt-1">
           {Object.entries(execution.dependencies).map(
             ([dependencyId, dependency]) => {
               return (
@@ -792,6 +766,8 @@ type RelationsSectionProps = {
   run: models.Run;
   step: models.Step;
   execution: models.Execution;
+  stepId: string;
+  attempt: number;
 };
 
 function RelationsSection({
@@ -799,7 +775,11 @@ function RelationsSection({
   run,
   step,
   execution,
+  stepId,
+  attempt,
 }: RelationsSectionProps) {
+  const { pathname } = useLocation();
+  const [searchParams] = useSearchParams();
   const parent = findExecution(run, step.parentId);
   return (
     <>
@@ -834,39 +814,45 @@ function RelationsSection({
       <div>
         <h3 className="uppercase text-sm font-bold text-slate-400">Children</h3>
         {execution.children.length ? (
-          <ul>
-            {Object.entries(groupBy(execution.children, "groupId")).map(
-              ([groupId, children]) => (
+          <ul className="flex flex-col gap-1 mt-1">
+            {Object.entries(execution.groups).map(([groupIdStr, groupName]) => {
+              const groupId = parseInt(groupIdStr, 10);
+              const count = execution.children.filter(
+                (c) => c.groupId == groupId,
+              ).length;
+              return (
                 <li key={groupId}>
-                  {groupId != "null" && (
-                    <h4 className="text-slate-600 mt-2">
-                      {execution.groups[groupId]}
-                    </h4>
-                  )}
-                  <ul>
-                    {children.map((child) => {
-                      const step = run.steps[child.stepId];
-                      return (
-                        <li key={`${child.stepId}/${child.attempt}`}>
-                          <StepLink
-                            runId={runId}
-                            stepId={child.stepId}
-                            attempt={child.attempt}
-                            className="rounded text-sm ring-offset-1 px-1"
-                            hoveredClassName="ring-2 ring-slate-300"
-                          >
-                            <span className="font-mono">{step.target}</span>{" "}
-                            <span className="text-slate-500">
-                              ({step.module})
-                            </span>
-                          </StepLink>
-                        </li>
-                      );
+                  <Link
+                    to={buildUrl(pathname, {
+                      ...Object.fromEntries(searchParams),
+                      group: `${stepId}-${attempt}-${groupId}`,
                     })}
-                  </ul>
+                    className="rounded border border-slate-200 bg-slate-200/50 hover:bg-slate-200 inline-block px-1 py-0.5 text-sm"
+                  >
+                    {groupName || <em>Unnamed group</em>} ({count})
+                  </Link>
                 </li>
-              ),
-            )}
+              );
+            })}
+            {execution.children
+              .filter((c) => isNil(c.groupId))
+              .map((child) => {
+                const step = run.steps[child.stepId];
+                return (
+                  <li key={`${child.stepId}/${child.attempt}`}>
+                    <StepLink
+                      runId={runId}
+                      stepId={child.stepId}
+                      attempt={child.attempt}
+                      className="rounded text-sm ring-offset-1 px-1"
+                      hoveredClassName="ring-2 ring-slate-300"
+                    >
+                      <span className="font-mono">{step.target}</span>{" "}
+                      <span className="text-slate-500">({step.module})</span>
+                    </StepLink>
+                  </li>
+                );
+              })}
           </ul>
         ) : (
           <p className="italic">None</p>
@@ -1354,6 +1340,8 @@ export default function StepDetail({
                 runId={runId}
                 run={run}
                 step={step}
+                stepId={stepId}
+                attempt={attempt}
                 execution={execution}
               />
               <DependenciesSection execution={execution} />

--- a/frontend/src/components/StepLink.tsx
+++ b/frontend/src/components/StepLink.tsx
@@ -14,6 +14,7 @@ type Props = {
   runId: string;
   stepId: string;
   attempt?: number;
+  group?: string;
   className?: string;
   activeClassName?: string;
   hoveredClassName?: string;
@@ -24,6 +25,7 @@ export default function StepLink({
   runId,
   stepId,
   attempt,
+  group,
   className,
   activeClassName,
   hoveredClassName,
@@ -55,6 +57,7 @@ export default function StepLink({
           ...Object.fromEntries(searchParams),
           step: isActive ? undefined : stepId,
           attempt: isActive ? undefined : attempt,
+          group,
         },
       )}
       className={classNames(

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -6,18 +6,28 @@ import {
 } from "@headlessui/react";
 import classNames from "classnames";
 
+const sizeStyles = {
+  xs: "max-w-md",
+  sm: "max-w-lg",
+  md: "max-w-xl",
+  lg: "max-w-2xl",
+  xl: "max-w-4xl",
+};
+
 type Props = {
   open: boolean;
   title?: ReactNode;
+  size?: keyof typeof sizeStyles;
   className?: string;
   onClose: () => void;
   children: ReactNode;
 };
 
 export default function Dialog({
-  title,
   open,
-  className = "p-6",
+  title,
+  size,
+  className,
   onClose,
   children,
 }: Props) {
@@ -28,19 +38,26 @@ export default function Dialog({
       transition
       onClose={onClose}
     >
-      <DialogPanel
+      <div
         className={classNames(
-          "bg-white shadow-xl rounded-lg w-full",
-          className,
+          "max-h-screen p-4 flex flex-col w-full items-center",
+          size ? sizeStyles[size] : "max-w-screen",
         )}
       >
-        {title && (
-          <DialogTitle className="text-2xl font-bold text-slate-900 mb-4">
-            {title}
-          </DialogTitle>
-        )}
-        {children}
-      </DialogPanel>
+        <DialogPanel
+          className={classNames(
+            "bg-white shadow-xl rounded-lg w-full flex-1 overflow-auto",
+            className,
+          )}
+        >
+          {title && (
+            <DialogTitle className="text-2xl font-bold text-slate-900 mb-4">
+              {title}
+            </DialogTitle>
+          )}
+          {children}
+        </DialogPanel>
+      </div>
     </HeadlessDialog>
   );
 }

--- a/frontend/src/graph.ts
+++ b/frontend/src/graph.ts
@@ -188,7 +188,17 @@ function traverseRun(
                 name: execution.groups[child.groupId],
                 steps: execution.children
                   .filter((c) => c.groupId === child.groupId)
-                  .reduce((acc, c) => ({ ...acc, [c.stepId]: c.attempt }), {}),
+                  .reduce(
+                    (acc, c) => ({
+                      ...acc,
+                      [c.stepId]: max(
+                        Object.keys(run.steps[c.stepId].executions).map((a) =>
+                          parseInt(a, 10),
+                        ),
+                      ),
+                    }),
+                    {},
+                  ),
                 activeStepId: child.stepId,
               }
             : group;

--- a/frontend/src/graph.ts
+++ b/frontend/src/graph.ts
@@ -141,9 +141,7 @@ function traverseRun(
     group: Group | null,
   ) => void,
   group: Group | null = null,
-  seen: Record<string, true> = {},
 ) {
-  const newSeen: Record<string, true> = { ...seen, [stepId]: true };
   const attempt = getStepAttempt(run, stepAttempts, stepId);
   if (attempt) {
     const execution = run.steps[stepId].executions[attempt];
@@ -169,7 +167,7 @@ function traverseRun(
       callback(stepId, attempt, children, group);
 
       children.forEach((child) => {
-        if (!(child.stepId in seen)) {
+        if (run.steps[child.stepId].parentId == execution.executionId) {
           const group = !isNil(child.groupId)
             ? {
                 name: execution.groups[child.groupId],
@@ -186,8 +184,9 @@ function traverseRun(
             child.stepId,
             callback,
             group,
-            newSeen,
           );
+        } else {
+          // TODO: ?
         }
       });
     }
@@ -375,7 +374,7 @@ export default function buildGraph(
         height,
       })),
       edges: Object.entries(edges)
-        .filter(([, { from, to }]) => from in nodes && to in nodes)
+        .filter(([, { from, to }]) => from in nodes && to in nodes) // TODO: remove?
         .map(([id, { from, to }]) => ({
           id,
           sources: [from],

--- a/frontend/src/graph.ts
+++ b/frontend/src/graph.ts
@@ -238,8 +238,8 @@ export default function buildGraph(
     height: 30,
   };
   edges["start"] = {
-    from: run.parent?.runId || "start",
-    to: initialStepId,
+    from: initialStepId,
+    to: run.parent?.runId || "start",
     type: "parent",
   };
 

--- a/frontend/src/graph.ts
+++ b/frontend/src/graph.ts
@@ -51,7 +51,7 @@ export type Edge = {
   from: string;
   to: string;
   path: { x: number; y: number }[];
-  type: "dependency" | "child" | "transitive" | "parent" | "asset";
+  type: "dependency" | "child" | "parent" | "asset";
 };
 
 export type Graph = {

--- a/frontend/src/graph.ts
+++ b/frontend/src/graph.ts
@@ -319,10 +319,9 @@ export default function buildGraph(
               (d) => d.execution.stepId == child.stepId,
             )
           ) {
-            // TODO: switch direction?
-            edges[`${stepId}-${child.stepId}`] = {
-              from: stepId,
-              to: child.stepId,
+            edges[`${child.stepId}-${stepId}`] = {
+              from: child.stepId,
+              to: stepId,
               type: "child",
             };
           }

--- a/frontend/src/graph.ts
+++ b/frontend/src/graph.ts
@@ -241,7 +241,7 @@ function buildChildren(
     ...groupIds.map((groupId) => ({
       id: groupId!,
       layoutOptions: {
-        "elk.padding": "[left=15, top=40, right=15, bottom=30]",
+        "elk.padding": "[left=15, top=40, right=15, bottom=15]",
         "elk.layered.spacing.nodeNodeBetweenLayers": "40",
       },
       children: Object.entries(nodes)

--- a/frontend/src/layouts/RunLayout.tsx
+++ b/frontend/src/layouts/RunLayout.tsx
@@ -23,6 +23,7 @@ import HoverContext from "../components/HoverContext";
 import { useTitlePart } from "../components/TitleContext";
 import WorkflowHeader from "../components/WorkflowHeader";
 import SensorHeader from "../components/SensorHeader";
+import GroupDialog from "../components/GroupDialog";
 
 type TabProps = {
   page: string | null;
@@ -143,6 +144,7 @@ export default function RunLayout() {
   const activeWorkspaceName = searchParams.get("workspace") || undefined;
   const activeTab = parseInt(searchParams.get("tab") || "", 10) || 0;
   const maximised = !!searchParams.get("maximised");
+  const activeGroupIdentifier = searchParams.get("group");
   const workspaces = useWorkspaces(projectId);
   const activeWorkspaceId = findKey(
     workspaces,
@@ -161,8 +163,14 @@ export default function RunLayout() {
   } else {
     return (
       <HoverContext>
+        <GroupDialog
+          runId={runId!}
+          run={run}
+          identifier={activeGroupIdentifier}
+          projectId={projectId!}
+        />
         <div
-          className={classNames("flex-1 flex flex-col relative")}
+          className="flex-1 flex flex-col relative"
           style={{ paddingRight: activeStepId && !maximised ? detailWidth : 0 }}
         >
           {initialStep.type == "sensor" ? (

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -162,6 +162,7 @@ export type Dependency = {
 export type Child = {
   stepId: string;
   attempt: number;
+  groupId: number | null;
 };
 
 export type Execution = {
@@ -171,6 +172,7 @@ export type Execution = {
   executeAfter: number | null;
   assignedAt: number | null;
   completedAt: number | null;
+  groups: Record<string, string>;
   dependencies: Record<string, Dependency>;
   children: Child[];
   result: Result | null;

--- a/frontend/src/pages/ChildrenPage.tsx
+++ b/frontend/src/pages/ChildrenPage.tsx
@@ -40,7 +40,7 @@ export default function ChildrenPage() {
           <tbody>
             {Object.keys(executions)
               .map((a) => parseInt(a, 10))
-              .sort()
+              .sort((a, b) => a - b)
               .map((attempt) => {
                 const spawned = findSpawned(run, executions[attempt]);
                 return (

--- a/frontend/src/pages/GraphPage.tsx
+++ b/frontend/src/pages/GraphPage.tsx
@@ -21,24 +21,16 @@ export default function GraphPage() {
   const activeAttempt = searchParams.has("attempt")
     ? parseInt(searchParams.get("attempt")!)
     : undefined;
-  if (Object.keys(run.steps).length < 1000) {
-    return (
-      <RunGraph
-        projectId={projectId!}
-        run={run}
-        width={width}
-        height={height}
-        runId={runId!}
-        activeStepId={activeStepId}
-        activeAttempt={activeAttempt}
-        runWorkspaceId={getRunWorkspaceId(run)}
-      />
-    );
-  } else {
-    return (
-      <div className="p-4">
-        <p className="italic text-slate-500">Run graph is too big to render.</p>
-      </div>
-    );
-  }
+  return (
+    <RunGraph
+      projectId={projectId!}
+      run={run}
+      width={width}
+      height={height}
+      runId={runId!}
+      activeStepId={activeStepId}
+      activeAttempt={activeAttempt}
+      runWorkspaceId={getRunWorkspaceId(run)}
+    />
+  );
 }

--- a/frontend/src/topics.ts
+++ b/frontend/src/topics.ts
@@ -121,14 +121,14 @@ export function useRun(
   runId: string | undefined,
   workspaceId: string | undefined,
 ) {
-  const [run] = useTopic<models.Run>(
+  const [run, { loading }] = useTopic<models.Run>(
     "projects",
     projectId,
     "runs",
     runId,
     workspaceId,
   );
-  return run;
+  return loading ? undefined : run;
 }
 
 export function useLogs(

--- a/server/README.md
+++ b/server/README.md
@@ -23,5 +23,6 @@ $ iex -S mix
 And build the frontend with:
 
 ``` bash
-$ npm run watch
+$ cd ../frontend
+$ npm run dev
 ```

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -62,6 +62,24 @@ defmodule Coflux.Handlers.Agent do
             {[], state}
         end
 
+      "register_group" ->
+        [parent_id, group_id, name] = message["params"]
+
+        if is_recognised_execution?(parent_id, state) do
+          case(
+            Orchestration.register_group(
+              state.project_id,
+              parent_id,
+              group_id,
+              name
+            )
+          ) do
+            :ok -> {[], state}
+          end
+        else
+          {[{:close, 4000, "execution_invalid"}], nil}
+        end
+
       "submit" ->
         [
           module,
@@ -69,6 +87,7 @@ defmodule Coflux.Handlers.Agent do
           type,
           arguments,
           parent_id,
+          group_id,
           wait_for,
           cache,
           defer,
@@ -86,6 +105,7 @@ defmodule Coflux.Handlers.Agent do
                  target,
                  parse_type(type),
                  Enum.map(arguments, &parse_value/1),
+                 group_id: group_id,
                  execute_after: execute_after,
                  wait_for: wait_for,
                  cache: parse_cache(cache),

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -75,6 +75,10 @@ defmodule Coflux.Orchestration do
     )
   end
 
+  def register_group(project_id, parent_id, group_id, name) do
+    call_server(project_id, {:register_group, parent_id, group_id, name})
+  end
+
   def cancel_execution(project_id, execution_id) do
     call_server(project_id, {:cancel_execution, execution_id})
   end

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1348,7 +1348,6 @@ defmodule Coflux.Orchestration.Server do
                target: step.target,
                type: step.type,
                parent_id: step.parent_id,
-               group_id: step.group_id,
                cache_config:
                  if(step.cache_config_id, do: Map.fetch!(cache_configs, step.cache_config_id)),
                cache_key: step.cache_key,

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -662,6 +662,7 @@ defmodule Coflux.Orchestration.Server do
          memo_hit: memo_hit,
          child_added: child_added
        }} ->
+        group_id = Keyword.get(opts, :group_id)
         cache = Keyword.get(opts, :cache)
         execute_after = Keyword.get(opts, :execute_after)
         requires = Keyword.get(opts, :requires) || %{}
@@ -701,7 +702,7 @@ defmodule Coflux.Orchestration.Server do
             notify_listeners(
               state,
               {:run, run.id},
-              {:child, parent_id, {external_step_id, attempt}}
+              {:child, parent_id, {external_step_id, attempt, group_id}}
             )
           else
             state
@@ -739,6 +740,23 @@ defmodule Coflux.Orchestration.Server do
           |> flush_notifications()
 
         {:reply, {:ok, run.external_id, external_step_id, execution_id}, state}
+    end
+  end
+
+  def handle_call({:register_group, parent_id, group_id, name}, _from, state) do
+    {:ok, run_id} = Runs.get_execution_run_id(state.db, parent_id)
+
+    case Runs.create_group(state.db, parent_id, group_id, name) do
+      :ok ->
+        state =
+          state
+          |> notify_listeners(
+            {:run, run_id},
+            {:group, parent_id, group_id, name}
+          )
+          |> flush_notifications()
+
+        {:reply, :ok, state}
     end
   end
 
@@ -1280,6 +1298,7 @@ defmodule Coflux.Orchestration.Server do
         {:ok, run_dependencies} = Runs.get_run_dependencies(state.db, run.id)
         {:ok, run_children} = Runs.get_run_children(state.db, run.id)
         {:ok, log_counts} = Observations.get_counts_for_run(state.db, run.id)
+        {:ok, groups} = Runs.get_groups_for_run(state.db, run.id)
 
         cache_configs =
           steps
@@ -1329,6 +1348,7 @@ defmodule Coflux.Orchestration.Server do
                target: step.target,
                type: step.type,
                parent_id: step.parent_id,
+               group_id: step.group_id,
                cache_config:
                  if(step.cache_config_id, do: Map.fetch!(cache_configs, step.cache_config_id)),
                cache_key: step.cache_key,
@@ -1342,6 +1362,12 @@ defmodule Coflux.Orchestration.Server do
                  |> Map.new(fn {execution_id, _step_id, attempt, workspace_id, execute_after,
                                 created_at, assigned_at} ->
                    {result, completed_at} = Map.fetch!(results, execution_id)
+
+                   execution_groups =
+                     groups
+                     |> Enum.filter(fn {execution_id, _, _} -> execution_id == execution_id end)
+                     |> Map.new(fn {_, group_id, name} -> {group_id, name} end)
+
                    # TODO: load assets in one query
                    {:ok, asset_ids} = Results.get_assets_for_execution(state.db, execution_id)
                    assets = Map.new(asset_ids, &{&1, resolve_asset(state.db, &1)})
@@ -1362,6 +1388,7 @@ defmodule Coflux.Orchestration.Server do
                       execute_after: execute_after,
                       assigned_at: assigned_at,
                       completed_at: completed_at,
+                      groups: execution_groups,
                       assets: assets,
                       dependencies: dependencies,
                       result: result,
@@ -1580,8 +1607,8 @@ defmodule Coflux.Orchestration.Server do
                         )
                         |> send_session(
                           session_id,
-                          {:execute, execution.execution_id, execution.module,
-                           execution.target, arguments}
+                          {:execute, execution.execution_id, execution.module, execution.target,
+                           arguments}
                         )
 
                       {state, [{execution, assigned_at} | assigned], unassigned}
@@ -2035,7 +2062,7 @@ defmodule Coflux.Orchestration.Server do
       !workspace.base_id ->
         false
 
-          workspace.base_id == maybe_ancestor_id ->
+      workspace.base_id == maybe_ancestor_id ->
         true
 
       true ->
@@ -2157,8 +2184,7 @@ defmodule Coflux.Orchestration.Server do
         fn execution, {due, future, defer, defer_keys} ->
           defer_key =
             execution.defer_key &&
-              {execution.module, execution.target, execution.workspace_id,
-               execution.defer_key}
+              {execution.module, execution.target, execution.workspace_id, execution.defer_key}
 
           defer_id = defer_key && Map.get(defer_keys, defer_key)
 

--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1364,7 +1364,7 @@ defmodule Coflux.Orchestration.Server do
 
                    execution_groups =
                      groups
-                     |> Enum.filter(fn {execution_id, _, _} -> execution_id == execution_id end)
+                     |> Enum.filter(fn {e_id, _, _} -> e_id == execution_id end)
                      |> Map.new(fn {_, group_id, name} -> {group_id, name} end)
 
                    # TODO: load assets in one query

--- a/server/lib/coflux/topics/logs.ex
+++ b/server/lib/coflux/topics/logs.ex
@@ -74,6 +74,7 @@ defmodule Coflux.Topics.Logs do
   end
 
   defp process_notification(topic, {:step, _, _, _}), do: topic
+  defp process_notification(topic, {:group, _, _, _}), do: topic
   defp process_notification(topic, {:asset, _, _, _}), do: topic
   defp process_notification(topic, {:assigned, _}), do: topic
   defp process_notification(topic, {:result_dependency, _, _, _}), do: topic

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -80,6 +80,7 @@ defmodule Coflux.Topics.Run do
           executeAfter: execute_after,
           assignedAt: nil,
           completedAt: nil,
+          groups: %{},
           assets: %{},
           dependencies: %{},
           children: [],
@@ -90,6 +91,12 @@ defmodule Coflux.Topics.Run do
     else
       topic
     end
+  end
+
+  defp process_notification(topic, {:group, execution_id, group_id, name}) do
+    update_execution(topic, execution_id, fn topic, base_path ->
+      Topic.set(topic, base_path ++ [:groups, Integer.to_string(group_id)], name)
+    end)
   end
 
   defp process_notification(topic, {:asset, execution_id, asset_id, asset}) do
@@ -204,6 +211,7 @@ defmodule Coflux.Topics.Run do
                     executeAfter: execution.execute_after,
                     assignedAt: execution.assigned_at,
                     completedAt: execution.completed_at,
+                    groups: execution.groups,
                     assets:
                       Map.new(execution.assets, fn {asset_id, asset} ->
                         {Integer.to_string(asset_id), build_asset(asset)}
@@ -281,8 +289,8 @@ defmodule Coflux.Topics.Run do
     end
   end
 
-  defp build_child({external_step_id, attempt}) do
-    %{stepId: external_step_id, attempt: attempt}
+  defp build_child({external_step_id, attempt, group_id}) do
+    %{stepId: external_step_id, attempt: attempt, groupId: group_id}
   end
 
   defp build_cache_config(cache_config) do

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -1,7 +1,4 @@
-CREATE TABLE tag_sets (
-  id INTEGER PRIMARY KEY,
-  hash BLOB NOT NULL UNIQUE
-) STRICT;
+CREATE TABLE tag_sets (id INTEGER PRIMARY KEY, hash BLOB NOT NULL UNIQUE) STRICT;
 
 CREATE TABLE tag_set_items (
   tag_set_id INTEGER NOT NULL,
@@ -10,10 +7,7 @@ CREATE TABLE tag_set_items (
   FOREIGN KEY (tag_set_id) REFERENCES tag_sets ON DELETE CASCADE
 ) STRICT;
 
-CREATE TABLE parameter_sets (
-  id INTEGER PRIMARY KEY,
-  hash BLOB NOT NULL UNIQUE
-) STRICT;
+CREATE TABLE parameter_sets (id INTEGER PRIMARY KEY, hash BLOB NOT NULL UNIQUE) STRICT;
 
 CREATE TABLE parameter_set_items (
   parameter_set_id INTEGER NOT NULL,
@@ -21,14 +15,11 @@ CREATE TABLE parameter_set_items (
   name TEXT NOT NULL,
   default_ TEXT,
   annotation TEXT,
-  PRIMARY KEY (parameter_set_id, position)
+  PRIMARY KEY (parameter_set_id, position),
   FOREIGN KEY (parameter_set_id) REFERENCES parameter_sets ON DELETE CASCADE
 ) STRICT;
 
-CREATE TABLE manifests (
-  id INTEGER PRIMARY KEY,
-  hash BLOB NOT NULL UNIQUE
-) STRICT;
+CREATE TABLE manifests (id INTEGER PRIMARY KEY, hash BLOB NOT NULL UNIQUE) STRICT;
 
 CREATE TABLE instructions (
   id INTEGER PRIMARY KEY,
@@ -79,9 +70,7 @@ CREATE TABLE sensors (
   FOREIGN KEY (parameter_set_id) REFERENCES parameter_sets ON DELETE RESTRICT
 ) STRICT;
 
-CREATE TABLE workspaces (
-  id INTEGER PRIMARY KEY
-) STRICT;
+CREATE TABLE workspaces (id INTEGER PRIMARY KEY) STRICT;
 
 CREATE TABLE workspace_manifests (
   workspace_id INTEGER NOT NULL,
@@ -159,7 +148,10 @@ CREATE TABLE agent_launch_results (
   error TEXT,
   created_at INTEGER NOT NULL,
   FOREIGN KEY (agent_id) REFERENCES agents,
-  CHECK (data IS NULL OR error IS NULL)
+  CHECK (
+    data IS NULL
+    OR error IS NULL
+  )
 ) STRICT;
 
 CREATE TABLE agent_states (
@@ -238,7 +230,10 @@ CREATE TABLE steps (
   FOREIGN KEY (requires_tag_set_id) REFERENCES tag_sets ON DELETE RESTRICT
 ) STRICT;
 
-CREATE UNIQUE INDEX steps_initial_step ON steps (run_id) WHERE parent_id IS NULL;
+CREATE UNIQUE INDEX steps_initial_step ON steps (run_id)
+WHERE
+  parent_id IS NULL;
+
 CREATE INDEX steps_cache_key ON steps (cache_key);
 
 CREATE TABLE step_arguments (
@@ -279,7 +274,7 @@ CREATE TABLE asset_metadata (
   FOREIGN KEY (asset_id) REFERENCES assets ON DELETE CASCADE
 ) STRICT;
 
-CREATE TABLE execution_assets(
+CREATE TABLE execution_assets (
   execution_id INTEGER NOT NULL,
   asset_id INTEGER NOT NULL,
   created_at INTEGER NOT NULL,
@@ -324,7 +319,7 @@ CREATE TABLE asset_dependencies (
   FOREIGN KEY (asset_id) REFERENCES assets ON DELETE RESTRICT
 ) STRICT;
 
-CREATE TABLE checkpoints(
+CREATE TABLE checkpoints (
   id INTEGER PRIMARY KEY,
   execution_id INTEGER NOT NULL,
   sequence INTEGER NOT NULL,
@@ -333,7 +328,7 @@ CREATE TABLE checkpoints(
   FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE
 ) STRICT;
 
-CREATE TABLE checkpoint_arguments(
+CREATE TABLE checkpoint_arguments (
   checkpoint_id INTEGER NOT NULL,
   position INTEGER NOT NULL,
   value_id INTEGER NOT NULL,
@@ -356,10 +351,7 @@ CREATE TABLE blobs (
   size INTEGER NOT NULL
 ) STRICT;
 
-CREATE TABLE fragment_formats (
-  id INTEGER PRIMARY KEY,
-  name TEXT NOT NULL UNIQUE
-) STRICT;
+CREATE TABLE fragment_formats (id INTEGER PRIMARY KEY, name TEXT NOT NULL UNIQUE) STRICT;
 
 CREATE TABLE fragments (
   id INTEGER PRIMARY KEY,
@@ -398,7 +390,9 @@ CREATE TABLE value_references (
   FOREIGN KEY (fragment_id) REFERENCES fragments ON DELETE RESTRICT,
   FOREIGN KEY (execution_id) REFERENCES executions ON DELETE RESTRICT,
   FOREIGN KEY (asset_id) REFERENCES assets ON DELETE RESTRICT,
-  CHECK ((fragment_id IS NOT NULL) + (execution_id IS NOT NULL) + (asset_id IS NOT NULL) = 1)
+  CHECK (
+    (fragment_id IS NOT NULL) + (execution_id IS NOT NULL) + (asset_id IS NOT NULL) = 1
+  )
 ) STRICT;
 
 CREATE TABLE errors (
@@ -408,7 +402,7 @@ CREATE TABLE errors (
   message TEXT NOT NULL
 ) STRICT;
 
-CREATE TABLE error_frames(
+CREATE TABLE error_frames (
   error_id INTEGER NOT NULL,
   depth INTEGER NOT NULL,
   file TEXT NOT NULL,
@@ -432,14 +426,42 @@ CREATE TABLE results (
   FOREIGN KEY (successor_id) REFERENCES executions ON DELETE RESTRICT,
   CHECK (
     CASE type
-      WHEN 0 THEN error_id AND NOT value_id
-      WHEN 1 THEN value_id AND NOT (successor_id OR error_id)
-      WHEN 2 THEN NOT (error_id OR value_id)
-      WHEN 3 THEN NOT (error_id OR successor_id OR value_id)
-      WHEN 4 THEN successor_id AND NOT (error_id OR value_id)
-      WHEN 5 THEN successor_id AND NOT (error_id OR value_id)
-      WHEN 6 THEN successor_id AND NOT (error_id OR value_id)
-      WHEN 7 THEN successor_id AND NOT (error_id OR value_id)
+      WHEN 0 THEN error_id
+      AND NOT value_id
+      WHEN 1 THEN value_id
+      AND NOT (
+        successor_id
+        OR error_id
+      )
+      WHEN 2 THEN NOT (
+        error_id
+        OR value_id
+      )
+      WHEN 3 THEN NOT (
+        error_id
+        OR successor_id
+        OR value_id
+      )
+      WHEN 4 THEN successor_id
+      AND NOT (
+        error_id
+        OR value_id
+      )
+      WHEN 5 THEN successor_id
+      AND NOT (
+        error_id
+        OR value_id
+      )
+      WHEN 6 THEN successor_id
+      AND NOT (
+        error_id
+        OR value_id
+      )
+      WHEN 7 THEN successor_id
+      AND NOT (
+        error_id
+        OR value_id
+      )
       ELSE FALSE
     END
   )
@@ -461,12 +483,12 @@ CREATE TABLE messages (
   FOREIGN KEY (template_id) REFERENCES message_templates ON DELETE RESTRICT
 ) STRICT;
 
-CREATE TABLE message_labels(
+CREATE TABLE message_labels (
   id INTEGER PRIMARY KEY,
   label TEXT NOT NULL UNIQUE
 ) STRICT;
 
-CREATE TABLE message_values(
+CREATE TABLE message_values (
   message_id INTEGER NOT NULL,
   label_id INTEGER NOT NULL,
   value_id INTEGER NOT NULL,

--- a/server/priv/migrations/orchestration/1.sql
+++ b/server/priv/migrations/orchestration/1.sql
@@ -283,14 +283,24 @@ CREATE TABLE execution_assets (
   FOREIGN KEY (asset_id) REFERENCES assets ON DELETE CASCADE
 ) STRICT;
 
+CREATE TABLE groups (
+  execution_id INTEGER NOT NULL,
+  group_id INTEGER NOT NULL,
+  name TEXT,
+  PRIMARY KEY (execution_id, group_id),
+  FOREIGN KEY (execution_id) REFERENCES executions ON DELETE CASCADE
+) STRICT;
+
 -- TODO: add 'type' (e.g., 'regular', memoised)
 CREATE TABLE children (
   parent_id INTEGER NOT NULL,
   child_id INTEGER NOT NULL,
+  group_id INTEGER,
   created_at INTEGER NOT NULL,
   PRIMARY KEY (parent_id, child_id),
   FOREIGN KEY (parent_id) REFERENCES executions ON DELETE CASCADE,
-  FOREIGN KEY (child_id) REFERENCES executions ON DELETE CASCADE
+  FOREIGN KEY (child_id) REFERENCES executions ON DELETE CASCADE,
+  FOREIGN KEY (parent_id, group_id) REFERENCES groups ON DELETE SET NULL
 ) STRICT;
 
 CREATE TABLE assignments (


### PR DESCRIPTION
This adds support for 'groups', which allow task executions to be collected together. This is particularly useful when calling tasks in loops - for example with map-reduce style workflows.

At the moment, if you start a lot of tasks in a loop, this can quickly lead to a large graph - especially if those tasks each start more tasks. In practice you're likely to only be interested in one of those tasks at a time.

In a workflow, a group can be created using a context manager, with an optional name:

```python
with cf.group("Count words"):
    for chapter in chapters:
        process_chapter(chapter)
```

Any tasks that are submitted within the group will belong to the group (including any tasks started by those tasks). In the UI, the first task of the group will be shown by default, with the option to switch between the other tasks:

![image](https://github.com/user-attachments/assets/8f679fb8-adbc-465d-9457-f1e3c3b069d0)

Clicking on the group selector allows switching between different tasks:

![image](https://github.com/user-attachments/assets/6e860c69-5c9b-4167-be1b-2474a0ef75b3)