### PR TITLE
Support selecting type of arguments in run dialog

### DIFF
--- a/frontend/src/components/common/Field.tsx
+++ b/frontend/src/components/common/Field.tsx
@@ -31,7 +31,7 @@ export default function Field({
             {label}
           </label>
           {hint && (
-            <span className="text-slate-400 ml-1 text-xs">({hint})</span>
+            <span className="text-slate-400 ml-1.5 text-xs">{hint}</span>
           )}
         </div>
         <div>{children}</div>

--- a/frontend/src/components/common/Select.tsx
+++ b/frontend/src/components/common/Select.tsx
@@ -27,14 +27,22 @@ const sizeStyles = {
 };
 
 type Props<T extends string> = {
-  value: T | null;
   options: Record<T, ReactNode> | T[];
   variant?: Variant;
   size?: Size;
-  empty?: string;
   className?: string;
-  onChange: (value: T | null) => void;
-};
+} & (
+  | {
+      empty: string;
+      value: T | null;
+      onChange: (value: T | null) => void;
+    }
+  | {
+      empty?: undefined;
+      value: T;
+      onChange: (value: T) => void;
+    }
+);
 
 export default function Select<T extends string>({
   value,
@@ -57,7 +65,7 @@ export default function Select<T extends string>({
         <ListboxButton
           id={fieldId}
           className={classNames(
-            "w-full flex items-center bg-slate-50 rounded-md shadow-xs border focus:outline-hidden focus:ring-3",
+            "w-full flex gap-1 items-center bg-slate-50 rounded-md shadow-xs border focus:outline-hidden focus:ring-3",
             variantStyles[variant || defaultVariant],
             sizeStyles[size],
           )}

--- a/frontend/src/models.ts
+++ b/frontend/src/models.ts
@@ -12,7 +12,7 @@ export type TagSet = Record<string, string[]>;
 
 export type Parameter = {
   name: string;
-  default: string;
+  default: string | null;
   annotation: string;
 };
 


### PR DESCRIPTION
This updates the run dialog to support selecting the type of argument, and infers this based on the annotation. Currently the value must be entered as JSON - this change adds support for common (JSON-compatible) types (strings, numbers, booleans, null) as well as JSON.