### PR TITLE
Server-side suspense

### DIFF
--- a/clients/python/coflux/__main__.py
+++ b/clients/python/coflux/__main__.py
@@ -351,7 +351,7 @@ def workspaces_create(
     name: str,
 ):
     """
-    Creates an workspace within the project.
+    Creates a workspace within the project.
     """
     base_id = None
     if base:
@@ -495,7 +495,7 @@ def workspaces_archive(
     host: str,
 ):
     """
-    Archives an workspace.
+    Archives a workspace.
     """
     workspaces = _api_request(
         "GET", host, "get_workspaces", params={"project": project}

--- a/clients/python/coflux/context.py
+++ b/clients/python/coflux/context.py
@@ -51,7 +51,7 @@ def group(name: str | None = None):
     return _get_channel().group(name)
 
 
-def suspense(timeout: float | None):
+def suspense(timeout: float | None = 0):
     return _get_channel().suspense(timeout)
 
 

--- a/frontend/src/layouts/ProjectLayout.tsx
+++ b/frontend/src/layouts/ProjectLayout.tsx
@@ -152,7 +152,7 @@ export default function ProjectLayout() {
   return (
     <Fragment>
       <Header projectId={projectId!} activeWorkspaceName={workspaceName} />
-      <div className="flex-1 flex min-h-0 bg-white overflow-hidden">
+      <div className="flex-1 flex min-h-0 overflow-hidden">
         <Sidebar
           projectId={projectId!}
           workspaceName={workspaceName!}

--- a/server/lib/coflux/handlers/agent.ex
+++ b/server/lib/coflux/handlers/agent.ex
@@ -217,17 +217,15 @@ defmodule Coflux.Handlers.Agent do
         {[], state}
 
       "suspend" ->
-        # TODO: also support specifying asset dependencies?
-        [execution_id, execute_after, dependency_ids] = message["params"]
+        [execution_id, execute_after] = message["params"]
         # TODO: validate execute_after
-        # TODO: validate dependency_ids
 
         if is_recognised_execution?(execution_id, state) do
           :ok =
             Orchestration.record_result(
               state.project_id,
               execution_id,
-              {:suspended, execute_after, dependency_ids}
+              {:suspended, execute_after, []}
             )
 
           {[], state}
@@ -236,14 +234,14 @@ defmodule Coflux.Handlers.Agent do
         end
 
       "get_result" ->
-        [execution_id, from_execution_id] = message["params"]
+        [execution_id, from_execution_id, timeout_ms] = message["params"]
 
         if is_recognised_execution?(from_execution_id, state) do
           case Orchestration.get_result(
                  state.project_id,
                  execution_id,
                  from_execution_id,
-                 state.session_id,
+                 timeout_ms,
                  message["id"]
                ) do
             {:ok, result} ->

--- a/server/lib/coflux/handlers/api.ex
+++ b/server/lib/coflux/handlers/api.ex
@@ -200,9 +200,7 @@ defmodule Coflux.Handlers.Api do
           :cowboy_req.reply(204, req)
 
         {:error, :descendants} ->
-          json_error_response(req, "bad_request",
-            details: %{"workspaceId" => "has_dependencies"}
-          )
+          json_error_response(req, "bad_request", details: %{"workspaceId" => "has_dependencies"})
 
         {:error, :not_found} ->
           json_error_response(req, "not_found", code: 404)
@@ -763,7 +761,6 @@ defmodule Coflux.Handlers.Api do
              Enum.reduce_while(value, {:ok, []}, fn parameter, {:ok, result} ->
                case parse_parameter(parameter) do
                  {:ok, parsed} -> {:cont, {:ok, [parsed | result]}}
-                 # {:error, error} -> {:halt, {:error, error}}
                end
              end) do
         {:ok, Enum.reverse(backwards)}

--- a/server/lib/coflux/orchestration.ex
+++ b/server/lib/coflux/orchestration.ex
@@ -103,10 +103,10 @@ defmodule Coflux.Orchestration do
     call_server(project_id, {:record_result, execution_id, result})
   end
 
-  def get_result(project_id, execution_id, from_execution_id, session_id, request_id) do
+  def get_result(project_id, execution_id, from_execution_id, timeout_ms, request_id) do
     call_server(
       project_id,
-      {:get_result, execution_id, from_execution_id, session_id, request_id}
+      {:get_result, execution_id, from_execution_id, timeout_ms, request_id}
     )
   end
 

--- a/server/lib/coflux/orchestration/workspaces.ex
+++ b/server/lib/coflux/orchestration/workspaces.ex
@@ -285,7 +285,7 @@ defmodule Coflux.Orchestration.Workspaces do
   end
 
   def update_pool(db, workspace_id, pool_name, pool) do
-    # TODO: validate pool
+    # TODO: validate pool (check launcher is specified)
 
     with_transaction(db, fn ->
       now = current_timestamp()

--- a/server/lib/coflux/topics/run.ex
+++ b/server/lib/coflux/topics/run.ex
@@ -67,7 +67,8 @@ defmodule Coflux.Topics.Run do
 
   defp process_notification(
          topic,
-         {:execution, step_id, attempt, execution_id, workspace_id, created_at, execute_after}
+         {:execution, step_id, attempt, execution_id, workspace_id, created_at, execute_after,
+          dependencies}
        ) do
     if workspace_id in topic.state.workspace_ids do
       Topic.set(
@@ -82,7 +83,10 @@ defmodule Coflux.Topics.Run do
           completedAt: nil,
           groups: %{},
           assets: %{},
-          dependencies: %{},
+          dependencies:
+            Map.new(dependencies, fn {dependency_id, dependency} ->
+              {Integer.to_string(dependency_id), build_dependency(dependency)}
+            end),
           children: [],
           result: nil,
           logCount: 0


### PR DESCRIPTION
This moves the management of suspense to the server. The implementation added in #26 manages suspense on the client side by setting a timer whilst waiting for a result. Moving this to the server allows (usefully) specifying a timeout of zero - this is a way of suspending unless the result is already ready, without waiting.