### PR TITLE
Asset tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 <p align="center">
-  <img src="logo.svg" width="350" alt="Coflux" />
+  <img src="logo.svg" width="250" alt="Coflux" />
 </p>
 
-Coflux is an open-source workflow engine. Use it to orchestrate and observe computational workflows, defined in plain Python. Suitable for data pipelines, background tasks, chat bots.
+Coflux is an open-source workflow engine. Use it to orchestrate and observe computational workflows defined in plain Python. Suitable for data pipelines, background tasks, agentic systems.
 
 ```python
-from coflux import workflow, task
+import coflux as cf
 import requests
 
-@task(retries=2)
-def fetch_splines(url):
+@cf.task(retries=2)
+def fetch_splines(url: str) -> list:
     return requests.get(url).json()
 
-@task()
-def reticulate(splines):
+@cf.task()
+def reticulate(splines: list) -> list:
     return list(reversed(splines))
 
-@workflow()
-def my_workflow(url):
+@cf.workflow()
+def my_workflow(url: str) -> None:
     reticulate(fetch_splines(url))
 ```
 

--- a/frontend/src/components/AssetDialog.tsx
+++ b/frontend/src/components/AssetDialog.tsx
@@ -130,7 +130,7 @@ function LocationBar({ asset, selected, assetId, run }: LocationBarProps) {
     (part, i, ps) => {
       if (part == "") {
         const child = asset.name || (
-          <span className="italic text-slate-800">{getAssetName(asset)}</span>
+          <span className="italic text-slate-800">Untitled</span>
         );
         return ["", IconFiles, child];
       } else if (part.endsWith("/")) {

--- a/frontend/src/components/AssetDialog.tsx
+++ b/frontend/src/components/AssetDialog.tsx
@@ -145,7 +145,7 @@ function LocationBar({ asset, selected, assetId, run }: LocationBarProps) {
     },
   );
   return (
-    <div className="p-3 flex items-center gap-2 min-w-0">
+    <div className="flex-1 p-3 flex items-center gap-2 min-w-0">
       <AssetSelector assetId={assetId} run={run} />
       <ol className="flex items-center gap-2 overflow-auto scrollbar-none">
         {segments.map(([path, icon, child], i) => {
@@ -416,7 +416,7 @@ export default function AssetDialog({ identifier, projectId, run }: Props) {
             maximised ? "h-full" : "h-[50vh]",
           )}
         >
-          <div className="border-b border-slate-200 flex justify-between">
+          <div className="border-b border-slate-200 flex">
             <LocationBar
               asset={asset}
               selected={selected}
@@ -428,13 +428,19 @@ export default function AssetDialog({ identifier, projectId, run }: Props) {
               onToggleMaximise={handleToggleMaximise}
             />
           </div>
-          {entry &&
-          (type?.startsWith("text/") || type?.startsWith("image/")) ? (
+          {entry && type?.startsWith("text/") ? (
             <iframe
               src={primaryBlobStore.url(entry.blobKey)}
               sandbox="allow-downloads allow-forms allow-modals allow-scripts"
               className="flex-1"
             ></iframe>
+          ) : entry && type?.startsWith("image/") ? (
+            <div className="flex-1 flex min-h-0 min-w-0">
+              <img
+                src={primaryBlobStore.url(entry.blobKey)}
+                className="object-contain mx-auto"
+              />
+            </div>
           ) : entry ? (
             <FileInfo
               entry={{ ...entry, path: selected }}

--- a/server/lib/coflux/orchestration/assets.ex
+++ b/server/lib/coflux/orchestration/assets.ex
@@ -2,7 +2,6 @@ defmodule Coflux.Orchestration.Assets do
   import Coflux.Store
 
   alias Coflux.Orchestration.Values
-  alias Coflux.Utils
 
   defp hash_asset(name, entries) do
     data =
@@ -31,7 +30,7 @@ defmodule Coflux.Orchestration.Assets do
           {:ok, asset_id}
 
         {:ok, nil} ->
-          external_id = Utils.generate_id(20)
+          {:ok, external_id} = generate_external_id(db, :assets, 2, "A")
 
           {:ok, asset_id} =
             insert_one(db, :assets, %{external_id: external_id, name: name, hash: {:blob, hash}})


### PR DESCRIPTION
This makes some minor tweaks to assets. Most notably to use `<img>` tags for image previews (rather than an iframe), to allow more control of sizing.

Also tidies up the repo README a bit.