### PR TITLE
Process executions in order

### DIFF
--- a/server/lib/coflux/orchestration/server.ex
+++ b/server/lib/coflux/orchestration/server.ex
@@ -1587,9 +1587,8 @@ defmodule Coflux.Orchestration.Server do
       end)
 
     {state, assigned, unassigned} =
-      executions_due
-      |> Enum.reverse()
-      |> Enum.reduce(
+      Enum.reduce(
+        executions_due,
         {state, [], []},
         fn
           execution, {state, assigned, unassigned} ->


### PR DESCRIPTION
This updates the order that executions are processed - they're now executed in the order that they're scheduled, which feels more intuitive.