### PR TITLE
Improvements to group header/selector

### DIFF
--- a/frontend/src/components/Badge.tsx
+++ b/frontend/src/components/Badge.tsx
@@ -7,15 +7,15 @@ type Intent = "success" | "danger" | "warning" | "info" | "none";
 function classNameForIntent(intent: Intent) {
   switch (intent) {
     case "success":
-      return "bg-green-100 text-green-500";
+      return "bg-green-100 text-green-800";
     case "danger":
-      return "bg-red-100 text-red-500";
+      return "bg-red-100 text-red-800";
     case "warning":
-      return "bg-yellow-100 text-yellow-500";
+      return "bg-yellow-100 text-yellow-800";
     case "info":
-      return "bg-blue-100 text-blue-500";
+      return "bg-blue-100 text-blue-800";
     case "none":
-      return "bg-slate-100 text-slate-500";
+      return "bg-slate-100 text-slate-800";
   }
 }
 

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -2,12 +2,14 @@ import Dialog from "./common/Dialog";
 import * as models from "../models";
 import StepLink from "./StepLink";
 import classNames from "classnames";
-import ExecutionStatus from "./ExecutionStatus";
-import { useCallback } from "react";
-import { max, omit } from "lodash";
+import { ComponentProps, useCallback } from "react";
+import { groupBy, max, omit } from "lodash";
 import { buildUrl } from "../utils";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import Value from "./Value";
+import { getBranchStatus } from "../graph";
+import Tabs, { Tab } from "./common/Tabs";
+import Badge from "./Badge";
 
 function findGroup(run: models.Run, identifier: string) {
   const parts = identifier.split("-");
@@ -28,6 +30,31 @@ function findGroup(run: models.Run, identifier: string) {
   return { name, steps };
 }
 
+type BranchStatus = ReturnType<typeof getBranchStatus>;
+
+const statusLabels: Record<BranchStatus, string> = {
+  errored: "Errored",
+  aborted: "Aborted",
+  suspended: "Suspended",
+  deferred: "Deferred",
+  completed: "Completed",
+  running: "Running",
+  assigning: "Assigning",
+};
+
+const statusIntents: Record<
+  BranchStatus,
+  ComponentProps<typeof Badge>["intent"]
+> = {
+  errored: "danger",
+  aborted: "warning",
+  suspended: "info",
+  deferred: "info",
+  completed: "none",
+  running: "info",
+  assigning: "info",
+};
+
 type StepsListProps = {
   run: models.Run;
   stepIds: string[];
@@ -36,62 +63,79 @@ type StepsListProps = {
 };
 
 function StepsList({ run, stepIds, runId, projectId }: StepsListProps) {
+  const stepsByStatus: Partial<Record<BranchStatus, string[]>> = groupBy(
+    stepIds,
+    (stepId) => getBranchStatus(run, stepId),
+  );
   return (
-    <ul className="flex flex-col overflow-auto divide-y">
-      {stepIds.map((stepId) => {
-        const step = run.steps[stepId];
-        const attempt = max(
-          Object.keys(step.executions).map((a) => parseInt(a, 10)),
-        )!;
-        const execution = step.executions[attempt];
-        return (
-          <li key={stepId} className="py-1">
-            <StepLink
-              runId={runId}
-              stepId={stepId}
-              attempt={attempt}
-              className={classNames(
-                "p-1 cursor-pointer rounded-sm flex flex-col data-active:bg-slate-100 hover:bg-slate-50",
-              )}
-              activeClassName="bg-slate-100"
-            >
-              <div className="flex items-center gap-1">
-                <div className="flex-1 flex items-baseline flex-wrap gap-1 leading-tight">
-                  <div className="flex items-baseline gap-1">
-                    <span className="text-slate-400 text-sm">
-                      {step.module}
-                    </span>
-                    <span className="text-slate-400">/</span>
-                  </div>
-                  <span className="flex items-baseline gap-1">
-                    <h2 className="font-mono">{step.target}</h2>
-                  </span>
-                </div>
-                <div className="flex gap-1 items-center">
-                  #{attempt}
-                  <ExecutionStatus execution={execution} step={step} />
-                </div>
-              </div>
-              <div>
-                {step.arguments.length > 0 && (
-                  <ol className="list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
-                    {step.arguments.map((argument, index) => (
-                      <li key={index}>
-                        <Value
-                          value={argument}
-                          projectId={projectId}
-                          className="align-middle"
-                        />
-                      </li>
-                    ))}
-                  </ol>
-                )}
-              </div>
-            </StepLink>
-          </li>
-        );
-      })}
-    </ul>
+    <Tabs>
+      {Object.entries(stepsByStatus).map(([status, stepIds]) => (
+        <Tab
+          key={status}
+          label={
+            <>
+              {statusLabels[status as BranchStatus]}{" "}
+              <Badge
+                label={stepIds.length.toString()}
+                intent={statusIntents[status as BranchStatus]}
+              />
+            </>
+          }
+        >
+          <ul className="pt-2 flex flex-col h-80 overflow-auto">
+            {stepIds.map((stepId) => {
+              const step = run.steps[stepId];
+              const attempt = max(
+                Object.keys(step.executions).map((a) => parseInt(a, 10)),
+              )!;
+              return (
+                <li key={stepId} className="py-0.5">
+                  <StepLink
+                    runId={runId}
+                    stepId={stepId}
+                    attempt={attempt}
+                    className={classNames(
+                      "px-2 py-1 cursor-pointer rounded-sm flex flex-col data-active:bg-slate-100 hover:bg-slate-50",
+                    )}
+                    activeClassName="bg-slate-100"
+                  >
+                    <div className="flex items-center gap-1">
+                      <div className="flex-1 flex items-baseline flex-wrap gap-1 leading-tight">
+                        <div className="flex items-baseline gap-1">
+                          <span className="text-slate-400 text-sm">
+                            {step.module}
+                          </span>
+                          <span className="text-slate-400">/</span>
+                        </div>
+                        <span className="flex items-baseline gap-1">
+                          <h2 className="font-mono">{step.target}</h2>
+                        </span>
+                      </div>
+                      <div className="flex gap-1 items-center">#{attempt}</div>
+                    </div>
+                    <div>
+                      {step.arguments.length > 0 && (
+                        <ol className="list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
+                          {step.arguments.map((argument, index) => (
+                            <li key={index}>
+                              <Value
+                                value={argument}
+                                projectId={projectId}
+                                className="align-middle"
+                              />
+                            </li>
+                          ))}
+                        </ol>
+                      )}
+                    </div>
+                  </StepLink>
+                </li>
+              );
+            })}
+          </ul>
+        </Tab>
+      ))}
+    </Tabs>
   );
 }
 
@@ -122,7 +166,7 @@ export default function GroupDialog({
       open={!!identifier}
       title={group ? group.name || <em>Unnamed group</em> : undefined}
       onClose={handleDialogClose}
-      size="md"
+      size="lg"
       className="p-6"
     >
       {group ? (

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -58,7 +58,7 @@ function StepsList({ stepIds, run, runId, projectId }: StepsListProps) {
             >
               <div>
                 {step.arguments.length > 0 ? (
-                  <ol className="flex flex-wrap gap-x-3 list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
+                  <ol className="flex flex-wrap items-center gap-x-3 list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
                     {step.arguments.map((argument, index) => (
                       <li key={index}>
                         <Value

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -111,15 +111,28 @@ type GroupStepsProps = {
   stepIds: string[];
   runId: string;
   projectId: string;
+  activeStepId: string | undefined;
 };
 
-function GroupSteps({ run, stepIds, runId, projectId }: GroupStepsProps) {
+function GroupSteps({
+  run,
+  stepIds,
+  runId,
+  projectId,
+  activeStepId,
+}: GroupStepsProps) {
   const stepsByStatus: Partial<Record<BranchStatus, string[]>> = groupBy(
     stepIds,
     (stepId) => getBranchStatus(run, stepId),
   );
+  const defaultIndex =
+    activeStepId !== undefined
+      ? Object.values(stepsByStatus).findIndex((stepIds) =>
+          stepIds.includes(activeStepId),
+        )
+      : undefined;
   return (
-    <Tabs className="px-4">
+    <Tabs className="px-4" defaultIndex={defaultIndex}>
       {Object.entries(stepsByStatus).map(([status, stepIds]) => {
         const stepsByTarget = groupBy(stepIds, (stepId) => {
           const step = run.steps[stepId];
@@ -178,6 +191,7 @@ type Props = {
   run: models.Run;
   identifier: string | null;
   projectId: string;
+  activeStepId: string | undefined;
 };
 
 export default function GroupDialog({
@@ -185,6 +199,7 @@ export default function GroupDialog({
   run,
   identifier,
   projectId,
+  activeStepId,
 }: Props) {
   const [searchParams] = useSearchParams();
   const { pathname } = useLocation();
@@ -208,6 +223,7 @@ export default function GroupDialog({
             stepIds={group.steps}
             runId={runId}
             projectId={projectId}
+            activeStepId={activeStepId}
           />
         </div>
       ) : identifier ? (

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -65,6 +65,7 @@ function StepsList({ stepIds, run, runId, projectId }: StepsListProps) {
                           value={argument}
                           projectId={projectId}
                           className="align-middle"
+                          concise={true}
                         />
                       </li>
                     ))}

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -107,6 +107,16 @@ const statusIntents: Record<
   assigning: "info",
 };
 
+const statuses: BranchStatus[] = [
+  "assigning",
+  "running",
+  "completed",
+  "deferred",
+  "suspended",
+  "aborted",
+  "errored",
+];
+
 type GroupStepsProps = {
   run: models.Run;
   stepIds: string[];
@@ -134,55 +144,58 @@ function GroupSteps({
       : undefined;
   return (
     <Tabs className="px-4" defaultIndex={defaultIndex}>
-      {Object.entries(stepsByStatus).map(([status, stepIds]) => {
-        const stepsByTarget = groupBy(stepIds, (stepId) => {
-          const step = run.steps[stepId];
-          return `${step.module}/${step.target}`;
-        });
-        return (
-          <Tab
-            key={status}
-            label={
-              <>
-                {statusLabels[status as BranchStatus]}{" "}
-                <Badge
-                  label={stepIds.length.toString()}
-                  intent={statusIntents[status as BranchStatus]}
-                />
-              </>
-            }
-          >
-            <div className="h-[50vh] overflow-auto relative">
-              <ul className="px-4">
-                {Object.values(stepsByTarget).map((stepIds) => {
-                  const { module, target } = run.steps[stepIds[0]];
-                  return (
-                    <li key={`${module}/${target}`}>
-                      <div className="flex items-baseline flex-wrap gap-1 leading-tight sticky top-0 bg-white pt-4 pb-2">
-                        <div className="flex items-baseline gap-1">
-                          <span className="text-slate-400 text-sm">
-                            {module}
+      {statuses
+        .filter((s) => stepsByStatus[s])
+        .map((status) => {
+          const stepIds = stepsByStatus[status]!;
+          const stepsByTarget = groupBy(stepIds, (stepId) => {
+            const step = run.steps[stepId];
+            return `${step.module}/${step.target}`;
+          });
+          return (
+            <Tab
+              key={status}
+              label={
+                <>
+                  {statusLabels[status]}{" "}
+                  <Badge
+                    label={stepIds.length.toString()}
+                    intent={statusIntents[status]}
+                  />
+                </>
+              }
+            >
+              <div className="h-[50vh] overflow-auto relative">
+                <ul className="px-4">
+                  {Object.values(stepsByTarget).map((stepIds) => {
+                    const { module, target } = run.steps[stepIds[0]];
+                    return (
+                      <li key={`${module}/${target}`}>
+                        <div className="flex items-baseline flex-wrap gap-1 leading-tight sticky top-0 bg-white pt-4 pb-2">
+                          <div className="flex items-baseline gap-1">
+                            <span className="text-slate-400 text-sm">
+                              {module}
+                            </span>
+                            <span className="text-slate-400">/</span>
+                          </div>
+                          <span className="flex items-baseline gap-1">
+                            <h2 className="font-mono">{target}</h2>
                           </span>
-                          <span className="text-slate-400">/</span>
                         </div>
-                        <span className="flex items-baseline gap-1">
-                          <h2 className="font-mono">{target}</h2>
-                        </span>
-                      </div>
-                      <StepsList
-                        stepIds={stepIds}
-                        run={run}
-                        runId={runId}
-                        projectId={projectId}
-                      />
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          </Tab>
-        );
-      })}
+                        <StepsList
+                          stepIds={stepIds}
+                          run={run}
+                          runId={runId}
+                          projectId={projectId}
+                        />
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            </Tab>
+          );
+        })}
     </Tabs>
   );
 }

--- a/frontend/src/components/GroupDialog.tsx
+++ b/frontend/src/components/GroupDialog.tsx
@@ -24,17 +24,75 @@ function findGroup(run: models.Run, identifier: string) {
   const name = execution.groups[groupId];
   const steps = execution.children
     .filter((c) => c.groupId == groupId)
-    .map((c) => c.stepId)
-    .reduce<Record<string, number>>(
-      (acc, sId) => ({
-        ...acc,
-        [sId]: max(
-          Object.keys(run.steps[sId].executions).map((a) => parseInt(a, 10)),
-        )!,
-      }),
-      {},
-    );
+    .map((c) => c.stepId);
   return { name, steps };
+}
+
+type StepsListProps = {
+  run: models.Run;
+  stepIds: string[];
+  runId: string;
+  projectId: string;
+};
+
+function StepsList({ run, stepIds, runId, projectId }: StepsListProps) {
+  return (
+    <ul className="flex flex-col overflow-auto divide-y">
+      {stepIds.map((stepId) => {
+        const step = run.steps[stepId];
+        const attempt = max(
+          Object.keys(step.executions).map((a) => parseInt(a, 10)),
+        )!;
+        const execution = step.executions[attempt];
+        return (
+          <li key={stepId} className="py-1">
+            <StepLink
+              runId={runId}
+              stepId={stepId}
+              attempt={attempt}
+              className={classNames(
+                "p-1 cursor-pointer rounded-sm flex flex-col data-active:bg-slate-100 hover:bg-slate-50",
+              )}
+              activeClassName="bg-slate-100"
+            >
+              <div className="flex items-center gap-1">
+                <div className="flex-1 flex items-baseline flex-wrap gap-1 leading-tight">
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-slate-400 text-sm">
+                      {step.module}
+                    </span>
+                    <span className="text-slate-400">/</span>
+                  </div>
+                  <span className="flex items-baseline gap-1">
+                    <h2 className="font-mono">{step.target}</h2>
+                  </span>
+                </div>
+                <div className="flex gap-1 items-center">
+                  #{attempt}
+                  <ExecutionStatus execution={execution} step={step} />
+                </div>
+              </div>
+              <div>
+                {step.arguments.length > 0 && (
+                  <ol className="list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
+                    {step.arguments.map((argument, index) => (
+                      <li key={index}>
+                        <Value
+                          value={argument}
+                          projectId={projectId}
+                          className="align-middle"
+                        />
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
+            </StepLink>
+          </li>
+        );
+      })}
+    </ul>
+  );
 }
 
 type Props = {
@@ -53,7 +111,7 @@ export default function GroupDialog({
   const [searchParams] = useSearchParams();
   const { pathname } = useLocation();
   const navigate = useNavigate();
-  const group = identifier && findGroup(run, identifier);
+  const group = identifier ? findGroup(run, identifier) : undefined;
   const handleDialogClose = useCallback(() => {
     navigate(
       buildUrl(pathname, omit(Object.fromEntries(searchParams), "group")),
@@ -68,58 +126,12 @@ export default function GroupDialog({
       className="p-6"
     >
       {group ? (
-        <ul className="flex flex-col overflow-auto divide-y">
-          {Object.entries(group.steps).map(([stepId, attempt]) => {
-            const step = run.steps[stepId];
-            const execution = step.executions[attempt];
-            return (
-              <li key={stepId} className="py-1">
-                <StepLink
-                  runId={runId}
-                  stepId={stepId}
-                  attempt={attempt}
-                  className={classNames(
-                    "p-1 cursor-pointer rounded-sm flex flex-col data-active:bg-slate-100 hover:bg-slate-50",
-                  )}
-                  activeClassName="bg-slate-100"
-                >
-                  <div className="flex items-center gap-1">
-                    <div className="flex-1 flex items-baseline flex-wrap gap-1 leading-tight">
-                      <div className="flex items-baseline gap-1">
-                        <span className="text-slate-400 text-sm">
-                          {step.module}
-                        </span>
-                        <span className="text-slate-400">/</span>
-                      </div>
-                      <span className="flex items-baseline gap-1">
-                        <h2 className="font-mono">{step.target}</h2>
-                      </span>
-                    </div>
-                    <div className="flex gap-1 items-center">
-                      #{attempt}
-                      <ExecutionStatus execution={execution} step={step} />
-                    </div>
-                  </div>
-                  <div>
-                    {step.arguments.length > 0 && (
-                      <ol className="list-decimal list-inside marker:text-slate-400 marker:text-xs space-y-1">
-                        {step.arguments.map((argument, index) => (
-                          <li key={index}>
-                            <Value
-                              value={argument}
-                              projectId={projectId}
-                              className="align-middle"
-                            />
-                          </li>
-                        ))}
-                      </ol>
-                    )}
-                  </div>
-                </StepLink>
-              </li>
-            );
-          })}
-        </ul>
+        <StepsList
+          run={run}
+          stepIds={group.steps}
+          runId={runId}
+          projectId={projectId}
+        />
       ) : identifier ? (
         <p>Unrecognised group</p>
       ) : null}

--- a/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/frontend/src/components/ProjectSettingsDialog.tsx
@@ -438,7 +438,7 @@ export default function SettingsDialog({ projectId, open, onClose }: Props) {
       size="lg"
     >
       <form onSubmit={handleSubmit}>
-        <Tabs>
+        <Tabs className="px-4">
           <SettingsTab label="Blob stores">
             <BlobStoresSettings
               stores={settings.blobStores}

--- a/frontend/src/components/RunGraph.tsx
+++ b/frontend/src/components/RunGraph.tsx
@@ -5,6 +5,7 @@ import {
   WheelEvent as ReactWheelEvent,
   useRef,
   useEffect,
+  ComponentProps,
 } from "react";
 import classNames from "classnames";
 import {
@@ -35,9 +36,10 @@ import SpaceLabel from "./SpaceLabel";
 import AssetIcon from "./AssetIcon";
 import { buildUrl } from "../utils";
 import AssetLink from "./AssetLink";
-import { countBy, isEqual, max } from "lodash";
+import { countBy, isEqual } from "lodash";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { getAssetName } from "../assets";
+import Badge from "./Badge";
 
 function resolveExecutionResult(
   run: models.Run,
@@ -344,14 +346,17 @@ function ChildNode({ child }: ChildNodeProps) {
   );
 }
 
-const groupHeaderStatusClassNames = {
-  deferred: "bg-slate-100 text-slate-500",
-  assigning: "bg-blue-100 text-slate-500",
-  running: "bg-blue-200 text-blue-800",
-  errored: "bg-red-200 text-red-800",
-  aborted: "bg-yellow-200 text-yellow-800",
-  suspended: "bg-slate-100 text-slate-500",
-  completed: "bg-green-200 text-green-800",
+const statusIntents: Record<
+  ReturnType<typeof getBranchStatus>,
+  ComponentProps<typeof Badge>["intent"]
+> = {
+  errored: "danger",
+  aborted: "warning",
+  suspended: "info",
+  deferred: "info",
+  completed: "none",
+  running: "info",
+  assigning: "info",
 };
 
 type GroupHeaderProps = {
@@ -389,7 +394,7 @@ function GroupHeader({ identifier, run }: GroupHeaderProps) {
           ...Object.fromEntries(searchParams),
           group: identifier,
         })}
-        className="flex items-center gap-0.5 rounded-md p-0.5 bg-white border border-slate-200 hover:border-slate-400 pointer-events-auto"
+        className="flex items-center gap-0.5 rounded-lg p-0.5 bg-white border border-slate-200 hover:border-slate-400 pointer-events-auto"
       >
         {(
           [
@@ -400,20 +405,16 @@ function GroupHeader({ identifier, run }: GroupHeaderProps) {
             "suspended",
             "aborted",
             "errored",
-          ] as ReturnType<typeof getExecutionStatus>[]
+          ] as ReturnType<typeof getBranchStatus>[]
         ).map(
           (status) =>
             !!counts[status] && (
-              <span
+              <Badge
                 key={status}
-                className={classNames(
-                  "px-1 rounded text-sm",
-                  groupHeaderStatusClassNames[status],
-                )}
+                label={`×${counts[status]}`}
                 title={`${counts[status]} ${status}`}
-              >
-                ×{counts[status]}
-              </span>
+                intent={statusIntents[status]}
+              />
             ),
         )}
         <IconSelector size={16} className="text-slate-500" />

--- a/frontend/src/components/StepDetail.tsx
+++ b/frontend/src/components/StepDetail.tsx
@@ -1309,7 +1309,7 @@ export default function StepDetail({
         maximised={maximised}
       />
       <Tabs
-        className={"flex-1 flex flex-col min-h-0"}
+        className="px-4"
         selectedIndex={activeTab}
         onChange={handleTabChange}
       >

--- a/frontend/src/components/Value.tsx
+++ b/frontend/src/components/Value.tsx
@@ -17,7 +17,7 @@ import {
   MenuItems,
   MenuSeparator,
 } from "@headlessui/react";
-import { humanSize } from "../utils";
+import { humanSize, pluralise } from "../utils";
 import StepLink from "./StepLink";
 import AssetLink from "./AssetLink";
 import AssetIcon from "./AssetIcon";
@@ -29,14 +29,20 @@ type DataProps = {
   data: models.Data;
   references: models.Reference[];
   projectId: string;
-  concise?: boolean;
+  concise: boolean | undefined;
 };
 
 function Data({ data, references, projectId, concise }: DataProps) {
   const blobStoresSetting = useSetting(projectId, "blobStores");
   if (Array.isArray(data)) {
     return (
-      <Fragment>
+      <span
+        title={
+          concise && data.length > 1
+            ? pluralise(data.length, "item")
+            : undefined
+        }
+      >
         [
         {(concise ? data.slice(0, 1) : data).map((item, index) => (
           <Fragment key={index}>
@@ -50,7 +56,7 @@ function Data({ data, references, projectId, concise }: DataProps) {
           </Fragment>
         ))}
         {concise && data.length > 1 ? "…" : null}]
-      </Fragment>
+      </span>
     );
   } else if (data && typeof data == "object" && "type" in data) {
     switch (data.type) {
@@ -90,6 +96,7 @@ function Data({ data, references, projectId, concise }: DataProps) {
                     data={item}
                     references={references}
                     projectId={projectId}
+                    concise={concise}
                   />
                   {index < data.items.length - 1 && ",\u00a0"}
                 </Fragment>
@@ -101,7 +108,13 @@ function Data({ data, references, projectId, concise }: DataProps) {
       case "dict": {
         const pairs = chunk(data.items, 2);
         return (
-          <Fragment>
+          <span
+            title={
+              concise && pairs.length > 1
+                ? pluralise(pairs.length, "item")
+                : undefined
+            }
+          >
             {"{"}
             {(concise ? pairs.slice(0, 1) : pairs).map(
               ([key, value], index) => (
@@ -113,6 +126,7 @@ function Data({ data, references, projectId, concise }: DataProps) {
                     data={key}
                     references={references}
                     projectId={projectId}
+                    concise={concise}
                   />
                   <IconArrowRightBar
                     size={20}
@@ -123,13 +137,14 @@ function Data({ data, references, projectId, concise }: DataProps) {
                     data={value}
                     references={references}
                     projectId={projectId}
+                    concise={concise}
                   />
                 </div>
               ),
             )}
-            {concise && data.items.length > 1 ? "…" : null}
+            {concise && pairs.length > 1 ? "…" : null}
             {"}"}
-          </Fragment>
+          </span>
         );
       }
       case "ref": {

--- a/frontend/src/components/common/Dialog.tsx
+++ b/frontend/src/components/common/Dialog.tsx
@@ -52,7 +52,7 @@ export default function Dialog({
           )}
         >
           {title && (
-            <DialogTitle className="text-2xl font-bold text-slate-900 mb-4">
+            <DialogTitle className="text-2xl font-bold text-slate-900 mb-3">
               {title}
             </DialogTitle>
           )}

--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -20,21 +20,24 @@ export function Tab({ className, children }: TabProps) {
 }
 
 type Props = ComponentProps<typeof TabGroup> & {
+  className?: string;
   children: ReactElement<TabProps> | ReactElement<TabProps>[];
 };
 
-export default function Tabs({ children, ...props }: Props) {
+export default function Tabs({ className, children, ...props }: Props) {
   const tabs = Array.isArray(children) ? children : [children];
   return (
     <TabGroup {...props}>
-      <TabList className="border-b border-slate-200 px-4">
+      <TabList className={classNames("border-b border-slate-200", className)}>
         {tabs.map((c, i) => (
           <HeadlessTab
             key={i}
             disabled={c.props.disabled}
-            className="text-sm px-2 py-2 border-cyan-500 data-selected:border-b-2 data-selected:font-semibold outline-hidden disabled:opacity-30 cursor-pointer"
+            className="text-sm px-0.5 py-1 border-cyan-500 data-selected:border-b-2 text-slate-600 data-selected:text-slate-900 outline-hidden disabled:opacity-30 not-disabled:cursor-pointer group"
           >
-            {c.props.label}
+            <span className="block px-1.5 py-0.5 rounded-md group-hover:bg-slate-50">
+              {c.props.label}
+            </span>
           </HeadlessTab>
         ))}
       </TabList>

--- a/frontend/src/layouts/RunLayout.tsx
+++ b/frontend/src/layouts/RunLayout.tsx
@@ -180,6 +180,7 @@ export default function RunLayout() {
           run={run}
           identifier={activeGroupIdentifier}
           projectId={projectId!}
+          activeStepId={activeStepId}
         />
         <div
           className="flex-1 flex flex-col relative"

--- a/frontend/src/layouts/RunLayout.tsx
+++ b/frontend/src/layouts/RunLayout.tsx
@@ -43,12 +43,16 @@ function Tab({ page, children }: TabProps) {
       end={true}
       className={({ isActive }) =>
         classNames(
-          "px-2 py-2 text-sm",
-          isActive && "inline-block border-b-2 border-cyan-500 font-semibold",
+          "px-0.5 py-1 text-sm group",
+          isActive
+            ? "inline-block border-b-2 border-cyan-500 text-slate-900"
+            : "text-slate-600",
         )
       }
     >
-      {children}
+      <span className="block px-1.5 py-0.5 rounded-md group-hover:bg-slate-50">
+        {children}
+      </span>
     </NavLink>
   );
 }
@@ -201,7 +205,7 @@ export default function RunLayout() {
             />
           ) : null}
           <div className="grow flex flex-col">
-            <div className="border-b px-5">
+            <div className="border-b px-5 flex">
               {initialStep.type == "sensor" && (
                 <Tab page="children">Children</Tab>
               )}


### PR DESCRIPTION
This makes some improvements to the group selector UI.

For the group header (shown in the graph), the statuses shown now consider the status of any child executions, not just the initial step. This is useful when the initial step is submitted and running asynchronously.

For the group dialog:

- Steps are split into tabs based on their status (considering child executions).
- Steps are grouped by their target, with only the arguments shown in the list.
- Argument values are truncated.