### PR TITLE
More asset previews

### DIFF
--- a/frontend/src/blobs.ts
+++ b/frontend/src/blobs.ts
@@ -70,11 +70,15 @@ class S3BlobStore implements BlobStore {
   }
 }
 
-export function createBlobStore(settings: settings.BlobStoreSettings) {
-  switch (settings.type) {
+export function createBlobStore(
+  settings: settings.BlobStoreSettings | undefined,
+) {
+  switch (settings?.type) {
     case "http":
       return new HttpBlobStore(settings);
     case "s3":
       return new S3BlobStore(settings);
+    default:
+      return undefined;
   }
 }

--- a/frontend/src/components/AssetDialog.tsx
+++ b/frontend/src/components/AssetDialog.tsx
@@ -4,8 +4,6 @@ import * as api from "../api";
 import {
   Fragment,
   ReactNode,
-  RefObject,
-  RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -334,13 +332,14 @@ type FileInfoProps = {
 };
 
 function FileInfo({ entry, blobStore }: FileInfoProps) {
+  const Icon = getIconForFileType(entry.metadata["type"] as string);
   return (
     <div className="flex-1 overflow-auto p-5 flex flex-col items-center justify-center gap-6">
       <div className="flex flex-col items-center">
-        <IconFile
-          size={40}
+        <Icon
+          size={100}
           strokeWidth={1}
-          className="shrink-0 text-slate-500 mb-2"
+          className="shrink-0 text-slate-200 mb-2"
         />
         <h1>{entry.path}</h1>
         <p className="text-slate-500 text-sm">{humanSize(entry.size)}</p>
@@ -358,7 +357,7 @@ function FileInfo({ entry, blobStore }: FileInfoProps) {
           Download
         </Button>
       ) : (
-        <BlobKey blobKey={entry.blobKey} />
+        <BlobKey blobKey={entry.blobKey} size="md" />
       )}
     </div>
   );

--- a/frontend/src/components/AssetDialog.tsx
+++ b/frontend/src/components/AssetDialog.tsx
@@ -483,6 +483,11 @@ export default function AssetDialog({ identifier, projectId, run }: Props) {
                 blobKey={entry.blobKey}
                 className="flex-1 overflow-auto p-4"
               />
+            ) : type == "application/pdf" ? (
+              <iframe
+                src={primaryBlobStore.url(entry.blobKey)}
+                className="flex-1"
+              ></iframe>
             ) : type?.startsWith("text/") ? (
               <iframe
                 src={primaryBlobStore.url(entry.blobKey)}

--- a/frontend/src/components/AssetDialog.tsx
+++ b/frontend/src/components/AssetDialog.tsx
@@ -22,7 +22,6 @@ import {
   IconAlertTriangle,
   IconChevronDown,
   IconDownload,
-  IconFile,
   IconFiles,
   IconFolder,
   IconLoader2,

--- a/frontend/src/components/AssetDialog.tsx
+++ b/frontend/src/components/AssetDialog.tsx
@@ -4,6 +4,7 @@ import * as api from "../api";
 import {
   Fragment,
   ReactNode,
+  RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -193,13 +194,31 @@ function LocationBar({ asset, selected, assetId, run }: LocationBarProps) {
 }
 
 type ToolbarProps = {
+  asset: models.Asset;
+  assetId: string | undefined;
+  selected: string;
   maximised: boolean;
   onToggleMaximise: () => void;
 };
 
-function Toolbar({ maximised, onToggleMaximise }: ToolbarProps) {
+function Toolbar({
+  asset,
+  assetId,
+  selected,
+  maximised,
+  onToggleMaximise,
+}: ToolbarProps) {
   return (
-    <div className="p-3">
+    <div className="flex items-center gap-3 p-3">
+      {selected == "" ? (
+        assetId && (
+          <span className="text-sm text-slate-600">
+            <span className="text-slate-400">Asset ID:</span> {assetId}
+          </span>
+        )
+      ) : selected && !selected.endsWith("/") ? (
+        <BlobKey blobKey={asset.entries[selected].blobKey} />
+      ) : null}
       <Button
         variant="secondary"
         outline={true}
@@ -547,6 +566,9 @@ export default function AssetDialog({ identifier, projectId, run }: Props) {
               run={run}
             />
             <Toolbar
+              asset={asset}
+              assetId={assetId}
+              selected={selected}
               maximised={maximised}
               onToggleMaximise={handleToggleMaximise}
             />

--- a/frontend/src/components/BlobKey.tsx
+++ b/frontend/src/components/BlobKey.tsx
@@ -1,0 +1,32 @@
+import { useState, useCallback } from "react";
+import { truncate } from "lodash";
+import { IconCopy, IconCheck } from "@tabler/icons-react";
+
+type BlobKeyProps = {
+  blobKey: string;
+};
+
+export default function BlobKey({ blobKey }: BlobKeyProps) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(blobKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1000);
+  }, [blobKey]);
+  return (
+    <button
+      className="flex gap-1 rounded-md bg-slate-50 items-center px-1.5 py-1 text-slate-600 group focus:outline-none"
+      title="Blob key (click to copy)"
+      onClick={handleCopy}
+    >
+      <span className="text-xs leading-none">
+        {truncate(blobKey, { length: 12, omission: "…" })}
+      </span>
+      {copied ? (
+        <IconCheck size={14} className="text-green-700" />
+      ) : (
+        <IconCopy size={14} className="opacity-50 group-hover:opacity-100" />
+      )}
+    </button>
+  );
+}

--- a/frontend/src/components/BlobKey.tsx
+++ b/frontend/src/components/BlobKey.tsx
@@ -1,12 +1,14 @@
 import { useState, useCallback } from "react";
 import { truncate } from "lodash";
 import { IconCopy, IconCheck } from "@tabler/icons-react";
+import classNames from "classnames";
 
 type BlobKeyProps = {
   blobKey: string;
+  size?: "md" | "sm";
 };
 
-export default function BlobKey({ blobKey }: BlobKeyProps) {
+export default function BlobKey({ blobKey, size = "md" }: BlobKeyProps) {
   const [copied, setCopied] = useState(false);
   const handleCopy = useCallback(async () => {
     await navigator.clipboard.writeText(blobKey);
@@ -15,11 +17,16 @@ export default function BlobKey({ blobKey }: BlobKeyProps) {
   }, [blobKey]);
   return (
     <button
-      className="flex gap-1 rounded-md bg-slate-50 items-center px-1.5 py-1 text-slate-600 group focus:outline-none"
+      className="flex gap-1 rounded-md bg-slate-50 items-center px-1.5 py-1 text-slate-500 group focus:outline-none"
       title="Blob key (click to copy)"
       onClick={handleCopy}
     >
-      <span className="text-xs leading-none">
+      <span
+        className={classNames(
+          size == "sm" ? "text-xs" : "text-sm",
+          "leading-none",
+        )}
+      >
         {truncate(blobKey, { length: 12, omission: "…" })}
       </span>
       {copied ? (

--- a/frontend/src/components/ProjectSettingsDialog.tsx
+++ b/frontend/src/components/ProjectSettingsDialog.tsx
@@ -100,7 +100,6 @@ function BlobStoreSettings({
         <button
           className="hover:enabled:bg-slate-200 rounded-sm p-1 disabled:text-slate-300"
           type="button"
-          disabled={count <= 1}
           onClick={handleRemoveClick}
         >
           <IconX size={16} />

--- a/frontend/src/components/Value.tsx
+++ b/frontend/src/components/Value.tsx
@@ -23,6 +23,7 @@ import AssetLink from "./AssetLink";
 import AssetIcon from "./AssetIcon";
 import Alert from "./common/Alert";
 import Button from "./common/Button";
+import BlobKey from "./BlobKey";
 import { useSetting } from "../settings";
 
 type DataProps = {
@@ -161,10 +162,10 @@ function Data({ data, references, projectId, concise }: DataProps) {
                 </span>
               );
             } else {
-              const primaryBlobStore = createBlobStore(blobStoresSetting[0]);
+              const blobStore = createBlobStore(blobStoresSetting[0]);
               return (
                 <Menu>
-                  <MenuButton className="bg-slate-100 rounded-sm px-1.5 py-0.5 text-xs font-sans inline-flex gap-1">
+                  <MenuButton className="bg-slate-100 rounded-sm px-1.5 py-0.5 text-xs font-sans inline-flex gap-1 focus:outline-none">
                     {reference.format}
                     <span className="text-slate-500">
                       ({humanSize(reference.size)})
@@ -178,33 +179,40 @@ function Data({ data, references, projectId, concise }: DataProps) {
                   <MenuItems
                     transition
                     anchor="bottom"
-                    className="bg-white shadow-xl rounded-md origin-top transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0"
+                    className="bg-white shadow-xl rounded-md origin-top transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0 focus:outline-none"
                   >
-                    <dl className="flex flex-col gap-1 p-2">
-                      {Object.entries(reference.metadata).map(
-                        ([key, value]) => (
-                          <div key={key}>
-                            <dt className="text-xs text-slate-500">{key}</dt>
-                            <dd className="text-sm text-slate-900">
-                              {typeof value == "string"
-                                ? value
-                                : JSON.stringify(value)}
-                            </dd>
-                          </div>
-                        ),
-                      )}
-                    </dl>
-                    <MenuSeparator className="my-1 h-px bg-slate-100" />
-                    <MenuItem>
-                      <a
-                        href={primaryBlobStore.url(reference.blobKey)}
-                        download
-                        className="text-sm m-1 p-1 rounded-md data-active:bg-slate-100 flex items-center gap-1"
-                      >
-                        <IconDownload size={16} />
-                        Download
-                      </a>
-                    </MenuItem>
+                    <div className="p-1 flex flex-col gap-1">
+                      <dl className="flex flex-col gap-1 p-1">
+                        {Object.entries(reference.metadata).map(
+                          ([key, value]) => (
+                            <div key={key}>
+                              <dt className="text-xs text-slate-500">{key}</dt>
+                              <dd className="text-sm text-slate-900">
+                                {typeof value == "string"
+                                  ? value
+                                  : JSON.stringify(value)}
+                              </dd>
+                            </div>
+                          ),
+                        )}
+                      </dl>
+                      <BlobKey blobKey={reference.blobKey} />
+                    </div>
+                    {blobStore && (
+                      <Fragment>
+                        <MenuSeparator className="my-1 h-px bg-slate-100" />
+                        <MenuItem>
+                          <a
+                            href={blobStore.url(reference.blobKey)}
+                            download
+                            className="text-sm m-1 p-1 rounded-md data-active:bg-slate-100 flex items-center gap-1"
+                          >
+                            <IconDownload size={16} />
+                            Download
+                          </a>
+                        </MenuItem>
+                      </Fragment>
+                    )}
                   </MenuItems>
                 </Menu>
               );

--- a/frontend/src/components/Value.tsx
+++ b/frontend/src/components/Value.tsx
@@ -196,7 +196,7 @@ function Data({ data, references, projectId, concise }: DataProps) {
                           ),
                         )}
                       </dl>
-                      <BlobKey blobKey={reference.blobKey} />
+                      <BlobKey blobKey={reference.blobKey} size="sm" />
                     </div>
                     {blobStore && (
                       <Fragment>

--- a/server/lib/coflux/handlers/root.ex
+++ b/server/lib/coflux/handlers/root.ex
@@ -7,6 +7,7 @@ defmodule Coflux.Handlers.Root do
         """
         <!DOCTYPE html>
         <html lang="en">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/app.css" />
         <link rel="icon" href="/static/icon.svg" />
         <div id="root"></div>


### PR DESCRIPTION
This updates the asset dialog to support showing previews for markdown and PDF files. And supports zooming in/out on images.

Also supports having no blob stores configured, in which case the blob key of a file will be shown, with support for copying this for use with the CLI commands introduced in #100.